### PR TITLE
FireExit: ape argparse, flesh out test cases and get everything to pass

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -170,20 +170,20 @@ class FireError(Exception):
 class FireExit(SystemExit):
   """An exception raised by Fire to the client in the case of a FireError.
 
-  Contains the trace of the Fire program.
+  The trace of the Fire program is available on the `trace` property.
 
   Note:
     Since this exception inherits from SystemExit/BaseException, you'll have to
     explicitly catch it with `except SystemExit` or `except FireExit`.
   """
-  def __init__(self, code, trace):
+  def __init__(self, code, component_trace):
     """
     Args:
       code (int): exit code for CLI
-      trace (FireTrace): the component trace generated from running the command.
+      component_trace (FireTrace): the component trace generated from running the command.
     """
     super(FireExit, self).__init__(code)
-    self.trace = trace
+    self.trace = component_trace
 
 
 def _PrintResult(component_trace, verbose=False):

--- a/fire/core.py
+++ b/fire/core.py
@@ -132,7 +132,7 @@ def Fire(component=None, command=None, name=None):
     result = component_trace.GetResult()
     print(
         helputils.HelpString(result, component_trace, component_trace.verbose))
-    raise FireExit(2, trace)
+    raise FireExit(2, component_trace)
   elif component_trace.show_trace and component_trace.show_help:
     print('Fire trace:\n{trace}\n'.format(trace=component_trace))
     result = component_trace.GetResult()
@@ -147,7 +147,7 @@ def Fire(component=None, command=None, name=None):
     print(
         helputils.HelpString(result, component_trace, component_trace.verbose))
     # ape argparse by exiting out quickly
-    raise FireExit(0, None)
+    raise FireExit(0, component_trace)
   else:
     _PrintResult(component_trace, verbose=component_trace.verbose)
     result = component_trace.GetResult()

--- a/fire/core.py
+++ b/fire/core.py
@@ -97,9 +97,8 @@ def Fire(component=None, command=None, name=None):
     If the trace command line argument is supplied, the FireTrace is returned
     and no FireExit is raised.
   Raises:
-    FireExit: If a FireError is encountered and trace command line argument is
-        not passed. FireExit will have `code` of 2, whereas code exceptions
-        will be bubbled up as exit status of 1.
+    FireExit: If a FireError (code 2) or exception in client code (code 1) is
+        encountered.
   """
   # Get args as a list.
   if command is None:
@@ -172,14 +171,16 @@ class FireExit(SystemExit):
 
   Contains the trace of the Fire program.
 
-  Attributes:
-    code (int): exit code for CLI
-    trace (FireTrace): the component trace generated from running the command.
   Note:
     Since this exception inherits from SystemExit/BaseException, you'll have to
     explicitly catch it with `except SystemExit` or `except FireExit`.
   """
   def __init__(self, code, trace):
+    """
+    Args:
+      code (int): exit code for CLI
+      trace (FireTrace): the component trace generated from running the command.
+    """
     super(FireExit, self).__init__(code)
     self.trace = trace
 

--- a/fire/core.py
+++ b/fire/core.py
@@ -92,13 +92,14 @@ def Fire(component=None, command=None, name=None):
     it's a class). When all arguments are consumed and there's no function left
     to call or class left to instantiate, the resulting current component is
     the final result.
+    If the trace command line argument is supplied, the FireTrace is printed
+    and a zero.
     If a Fire error is encountered, the Fire Trace is displayed to stdout and
     a FireExit is raised.
-    If the trace command line argument is supplied, the FireTrace is returned
-    and no FireExit is raised.
   Raises:
     FireExit: If a FireError (code 2) or exception in client code (code 1) is
-        encountered.
+        encountered. When displaying help or trace, a FireExit with code of 0
+        will be raised.
   """
   # Get args as a list.
   if command is None:
@@ -137,10 +138,10 @@ def Fire(component=None, command=None, name=None):
     result = component_trace.GetResult()
     print(
         helputils.HelpString(result, component_trace, component_trace.verbose))
-    return component_trace
+    raise FireExit(0, component_trace)
   elif component_trace.show_trace:
     print('Fire trace:\n{trace}'.format(trace=component_trace))
-    return component_trace
+    raise FireExit(0, component_trace)
   elif component_trace.show_help:
     result = component_trace.GetResult()
     print(

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -16,40 +16,16 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from fire import core
-from fire import test_components as tc
-from fire import trace
-import contextlib
 import mock
-import re
-import six
-import sys
 import unittest
 
-
-class BaseTest(unittest.TestCase):
-  @contextlib.contextmanager
-  def assertRaisesFireExit(self, code, regexp=None):
-    """Avoids some boiler plate to make it easier to check a system exit is
-        raised and regexp is matched"""
-    if regexp is None:
-      regexp = '.*'
-    with self.assertRaises(core.FireExit):
-      stdout = six.StringIO()
-      with mock.patch.object(sys, 'stdout', stdout):
-        try:
-          yield
-        except core.FireExit as exc:
-          assert exc.code == code, 'Incorrect exit code: %r != %r' % (exc.code, code)
-          self.assertIsInstance(exc.trace, trace.FireTrace)
-          stdout.flush()
-          stdout.seek(0)
-          value = stdout.getvalue()
-          assert re.search(regexp, value, re.DOTALL | re.MULTILINE), 'Expected %r to match %r' % (value, regexp)
-          raise
+from fire import core
+from fire import test_components as tc
+from fire import testutils
+from fire import trace
 
 
-class CoreTest(BaseTest):
+class CoreTest(testutils.BaseTestCase):
   def testOneLineResult(self):
     self.assertEqual(core._OneLineResult(1), '1')
     self.assertEqual(core._OneLineResult('hello'), 'hello')

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -41,6 +41,7 @@ class BaseTest(unittest.TestCase):
           yield
         except core.FireExit as exc:
           assert exc.code == code, 'Incorrect exit code: %r != %r' % (exc.code, code)
+          self.assertIsInstance(exc.trace, trace.FireTrace)
           stdout.flush()
           stdout.seek(0)
           value = stdout.getvalue()

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -92,7 +92,7 @@ class CoreTest(BaseTest):
   def testImproperUseOfHelp(self):
     # This should produce a help message
     with self.assertRaisesFireExit(2, 'The proper way to show help.*Usage:'):
-      self.assertIsNone(core.Fire(tc.TypedProperties, 'alpha --help'))
+      core.Fire(tc.TypedProperties, 'alpha --help')
 
   def testProperUseOfHelp(self):
     # ape argparse

--- a/fire/fire_import_test.py
+++ b/fire/fire_import_test.py
@@ -24,7 +24,7 @@ class FireImportTest(unittest.TestCase):
 
   def testFire(self):
     with mock.patch.object(sys, 'argv', ['commandname']):
-        fire.Fire()
+      fire.Fire()
 
   def testFireMethods(self):
     self.assertIsNotNone(fire.Fire)

--- a/fire/fire_import_test.py
+++ b/fire/fire_import_test.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import fire
-
+import mock
+import sys
 import unittest
+
+import fire
 
 
 class FireImportTest(unittest.TestCase):
   """Tests importing Fire."""
 
   def testFire(self):
-    fire.Fire()
+    with mock.patch.object(sys, 'argv', ['commandname']):
+        fire.Fire()
 
   def testFireMethods(self):
     self.assertIsNotNone(fire.Fire)

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -297,11 +297,11 @@ class FireTest(testutils.BaseTestCase):
 
   def testHelpFlag(self):
     with self.assertRaisesFireExit(0):
-        fire.Fire(tc.BoolConverter, 'as-bool True -- --help')
+      fire.Fire(tc.BoolConverter, 'as-bool True -- --help')
     with self.assertRaisesFireExit(0):
-        fire.Fire(tc.BoolConverter, 'as-bool True -- -h')
+      fire.Fire(tc.BoolConverter, 'as-bool True -- -h')
     with self.assertRaisesFireExit(0):
-        fire.Fire(tc.BoolConverter, '-- --help')
+      fire.Fire(tc.BoolConverter, '-- --help')
 
   def testHelpFlagAndTraceFlag(self):
     self.assertIsInstance(

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -288,12 +288,12 @@ class FireTest(testutils.BaseTestCase):
                      ('value', {'nothing': False}))
 
   def testTraceFlag(self):
-    self.assertIsInstance(
-        fire.Fire(tc.BoolConverter, 'as-bool True -- --trace'), trace.FireTrace)
-    self.assertIsInstance(
-        fire.Fire(tc.BoolConverter, 'as-bool True -- -t'), trace.FireTrace)
-    self.assertIsInstance(
-        fire.Fire(tc.BoolConverter, '-- --trace'), trace.FireTrace)
+    with self.assertRaisesFireExit(0, 'Fire trace:\n'):
+      fire.Fire(tc.BoolConverter, 'as-bool True -- --trace')
+    with self.assertRaisesFireExit(0, 'Fire trace:\n'):
+      fire.Fire(tc.BoolConverter, 'as-bool True -- -t')
+    with self.assertRaisesFireExit(0, 'Fire trace:\n'):
+      fire.Fire(tc.BoolConverter, '-- --trace')
 
   def testHelpFlag(self):
     with self.assertRaisesFireExit(0):
@@ -304,13 +304,12 @@ class FireTest(testutils.BaseTestCase):
       fire.Fire(tc.BoolConverter, '-- --help')
 
   def testHelpFlagAndTraceFlag(self):
-    self.assertIsInstance(
-        fire.Fire(tc.BoolConverter, 'as-bool True -- --help --trace'),
-        trace.FireTrace)
-    self.assertIsInstance(
-        fire.Fire(tc.BoolConverter, 'as-bool True -- -h -t'), trace.FireTrace)
-    self.assertIsInstance(
-        fire.Fire(tc.BoolConverter, '-- -h --trace'), trace.FireTrace)
+    with self.assertRaisesFireExit(0, 'Fire trace:\n.*Usage:'):
+      fire.Fire(tc.BoolConverter, 'as-bool True -- --help --trace')
+    with self.assertRaisesFireExit(0, 'Fire trace:\n.*Usage:'):
+      fire.Fire(tc.BoolConverter, 'as-bool True -- -h -t')
+    with self.assertRaisesFireExit(0, 'Fire trace:\n.*Usage:'):
+      fire.Fire(tc.BoolConverter, '-- -h --trace')
 
   def testTabCompletionNoName(self):
     with self.assertRaises(ValueError):

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -19,17 +19,17 @@ from __future__ import print_function
 import fire
 from fire import test_components as tc
 from fire import trace
+from fire.core_test import BaseTest
 
 import six
 import unittest
 
 
-class FireTest(unittest.TestCase):
-
+class FireTest(BaseTest):
   def testFire(self):
-    fire.Fire(tc.Empty)
-    fire.Fire(tc.OldStyleEmpty)
-    fire.Fire(tc.WithInit)
+    fire.Fire(tc.Empty, '')
+    fire.Fire(tc.OldStyleEmpty, '')
+    fire.Fire(tc.WithInit, '')
     self.assertEqual(fire.Fire(tc.NoDefaults, 'double 2'), 4)
     self.assertEqual(fire.Fire(tc.NoDefaults, 'triple 4'), 12)
     self.assertEqual(fire.Fire(tc.WithDefaults, 'double 2'), 4)
@@ -293,9 +293,12 @@ class FireTest(unittest.TestCase):
         fire.Fire(tc.BoolConverter, '-- --trace'), trace.FireTrace)
 
   def testHelpFlag(self):
-    self.assertIsNone(fire.Fire(tc.BoolConverter, 'as-bool True -- --help'))
-    self.assertIsNone(fire.Fire(tc.BoolConverter, 'as-bool True -- -h'))
-    self.assertIsNone(fire.Fire(tc.BoolConverter, '-- --help'))
+    with self.assertRaisesFireExit(0):
+        fire.Fire(tc.BoolConverter, 'as-bool True -- --help')
+    with self.assertRaisesFireExit(0):
+        fire.Fire(tc.BoolConverter, 'as-bool True -- -h')
+    with self.assertRaisesFireExit(0):
+        fire.Fire(tc.BoolConverter, '-- --help')
 
   def testHelpFlagAndTraceFlag(self):
     self.assertIsInstance(

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -21,15 +21,18 @@ from fire import test_components as tc
 from fire import testutils
 from fire import trace
 
+import mock
 import six
+import sys
 import unittest
 
 
 class FireTest(testutils.BaseTestCase):
   def testFire(self):
-    fire.Fire(tc.Empty, '')
-    fire.Fire(tc.OldStyleEmpty, '')
-    fire.Fire(tc.WithInit, '')
+    with mock.patch.object(sys, 'argv', ['progname']):
+      fire.Fire(tc.Empty)
+      fire.Fire(tc.OldStyleEmpty)
+      fire.Fire(tc.WithInit)
     self.assertEqual(fire.Fire(tc.NoDefaults, 'double 2'), 4)
     self.assertEqual(fire.Fire(tc.NoDefaults, 'triple 4'), 12)
     self.assertEqual(fire.Fire(tc.WithDefaults, 'double 2'), 4)

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -18,14 +18,14 @@ from __future__ import print_function
 
 import fire
 from fire import test_components as tc
+from fire import testutils
 from fire import trace
-from fire.core_test import BaseTest
 
 import six
 import unittest
 
 
-class FireTest(BaseTest):
+class FireTest(testutils.BaseTestCase):
   def testFire(self):
     fire.Fire(tc.Empty, '')
     fire.Fire(tc.OldStyleEmpty, '')
@@ -335,7 +335,7 @@ class FireTest(BaseTest):
         ('-', '_'))
 
     # The separator triggers a function call, but there aren't enough arguments.
-    with self.assertRaises(fire.FireExit):
+    with self.assertRaisesFireExit(2):
       fire.Fire(tc.MixedDefaults, 'identity - _ +')
 
   def testNonComparable(self):

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -110,6 +110,7 @@ class TypedProperties(object):
     }
     self.echo = ['alex', 'bethany']
     self.fox = ('carry', 'divide')
+    self.gamma = 'myexcitingstring'
 
 
 class VarArgs(object):

--- a/fire/testutils.py
+++ b/fire/testutils.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import contextlib
+import re
+import sys
+import unittest
+
+import mock
+import six
+
+from fire import core
+from fire import trace
+
+class BaseTestCase(unittest.TestCase):
+  """Shared test case for fire tests"""
+
+  @contextlib.contextmanager
+  def assertRaisesFireExit(self, code, regexp=None):
+    """Avoids some boiler plate to make it easier to check a system exit is
+        raised and regexp is matched"""
+    if regexp is None:
+      regexp = '.*'
+    with self.assertRaises(core.FireExit):
+      stdout = six.StringIO()
+      with mock.patch.object(sys, 'stdout', stdout):
+        try:
+          yield
+        except core.FireExit as exc:
+          assert exc.code == code, 'Incorrect exit code: %r != %r' % (exc.code, code)
+          self.assertIsInstance(exc.trace, trace.FireTrace)
+          stdout.flush()
+          stdout.seek(0)
+          value = stdout.getvalue()
+          assert re.search(regexp, value, re.DOTALL | re.MULTILINE), 'Expected %r to match %r' % (value, regexp)
+          raise
+
+

--- a/fire/testutils.py
+++ b/fire/testutils.py
@@ -42,12 +42,13 @@ class BaseTestCase(unittest.TestCase):
         try:
           yield
         except core.FireExit as exc:
-          assert exc.code == code, 'Incorrect exit code: %r != %r' % (exc.code, code)
+          if exc.code != code:
+            raise AssertionError('Incorrect exit code: %r != %r' % (exc.code,
+                                                                    code))
           self.assertIsInstance(exc.trace, trace.FireTrace)
           stdout.flush()
           stdout.seek(0)
           value = stdout.getvalue()
-          assert re.search(regexp, value, re.DOTALL | re.MULTILINE), 'Expected %r to match %r' % (value, regexp)
+          if not re.search(regexp, value, re.DOTALL | re.MULTILINE):
+            raise AssertionError('Expected %r to match %r' % (value, regexp))
           raise
-
-


### PR DESCRIPTION
@dbieber 

1. Update documentation slightly (I also changed `__init__` name to be `code` because that matches the actual property name on SystemExit)
2. Get all tests to pass and note some additional edge cases (specifically, I'm suggesting we differentiate exit codes from FireError (`2`) from exit codes from user exceptions (`1`))
3. add helper method to capture all stdout and make it easier to write regexps for comparison (i.e. check that we show "the proper..." message on bad use of help)
4. on proper `-- --help` do the same thing as argparse and exit 0

For 4:

```
# given example.py
try:
    argparse.ArgumentParser().parse_args()
except BaseException as exc:
    print type(exc), exc
    raise


›› python example.py blah; echo "Exit status $?"
usage: example.py [-h]
example.py: error: unrecognized arguments: blah
SystemExit 2
Exit status 2
›› python example.py --help; echo "Exit status $?"                                                                                                                         usage: example.py [-h]

optional arguments:
  -h, --help  show this help message and exit
SystemExit 0
Exit status 0
```