### PR TITLE
Fix failing tests on Windows due to hardcoded file paths

### DIFF
--- a/fire/helputils_test.py
+++ b/fire/helputils_test.py
@@ -21,6 +21,7 @@ from fire import test_components as tc
 import six
 
 import unittest
+import os
 
 
 class HelpUtilsTest(unittest.TestCase):
@@ -120,7 +121,7 @@ class HelpUtilsTest(unittest.TestCase):
       self.assertIn('Type:        type\n', helpstring)
     self.assertIn('String form: ', helpstring)
     self.assertIn('fire.test_components.OldStyleEmpty', helpstring)
-    self.assertIn('fire/test_components.py\n', helpstring)
+    self.assertIn(os.path.join('fire', 'test_components.py\n'), helpstring)
     self.assertIn('Line:        ', helpstring)
 
 

--- a/fire/helputils_test.py
+++ b/fire/helputils_test.py
@@ -121,7 +121,7 @@ class HelpUtilsTest(unittest.TestCase):
       self.assertIn('Type:        type\n', helpstring)
     self.assertIn('String form: ', helpstring)
     self.assertIn('fire.test_components.OldStyleEmpty', helpstring)
-    self.assertIn(os.path.join('fire', 'test_components.py\n'), helpstring)
+    self.assertIn(os.path.join('fire', 'test_components.py'), helpstring)
     self.assertIn('Line:        ', helpstring)
 
 

--- a/fire/inspectutils_test.py
+++ b/fire/inspectutils_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import unittest
 import six
+import os
 
 from fire import inspectutils
 from fire import test_components as tc
@@ -97,7 +98,7 @@ class InspectUtilsTest(unittest.TestCase):
   def testInfoClass(self):
     info = inspectutils.Info(tc.NoDefaults)
     self.assertEqual(info.get('type_name'), 'type')
-    self.assertIn('fire/test_components.py', info.get('file'))
+    self.assertIn(os.path.join('fire', 'test_components.py'), info.get('file'))
     self.assertGreater(info.get('line'), 0)
 
   def testInfoClassNoInit(self):
@@ -106,7 +107,7 @@ class InspectUtilsTest(unittest.TestCase):
       self.assertEqual(info.get('type_name'), 'classobj')
     else:
       self.assertEqual(info.get('type_name'), 'type')
-    self.assertIn('fire/test_components.py', info.get('file'))
+    self.assertIn(os.path.join('fire', 'test_components.py'), info.get('file'))
     self.assertGreater(info.get('line'), 0)
 
 


### PR DESCRIPTION
Some of the tests are currently failing on windows because the file paths are hardcoded for unix systems. For example, one test is checking for the presence of the below string:

`fire/test_components.py`

The problem is on the windows the actual string that appears is:

`fire\test_components.py`


This is a solved problem, [`os.path.join`](https://docs.python.org/2/library/os.path.html#os.path.join) is smart enough to figure out how to correctly join the files for whatever system the code is being executed on. The tests should now pass on both Windows and Unix systems. 
