### PR TITLE
Fix NameError: name 'x' is not defined in Argument Parsing example

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -567,7 +567,7 @@ of any argument we give it:
 
 ```python
 import fire
-fire.Fire(lambda obj: type(x).__name__)
+fire.Fire(lambda obj: type(obj).__name__)
 ```
 
 And we'll use it like so:


### PR DESCRIPTION
```python
fire.Fire(lambda obj: type(x).__name__) 
```
was causing a name error, changed `x` to `obj`