### PR TITLE
BUG: fix output printing on dict with no printable keys

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -214,21 +214,20 @@ def _DictAsString(result, verbose=False):
   Returns:
     A string representing the dict
   """
+  result = {key: value for key, value in result.items()
+            if _ComponentVisible(key, verbose)}
+
   if not result:
     return '{}'
 
-  longest_key = max(
-      len(str(key)) for key in result.keys()
-      if _ComponentVisible(key, verbose)
-  )
+  longest_key = max(len(str(key)) for key in result.keys())
   format_string = '{{key:{padding}s}} {{value}}'.format(padding=longest_key + 1)
 
   lines = []
   for key, value in result.items():
-    if _ComponentVisible(key, verbose):
-      line = format_string.format(
-          key=str(key) + ':', value=_OneLineResult(value))
-      lines.append(line)
+    line = format_string.format(key=str(key) + ':',
+                                value=_OneLineResult(value))
+    lines.append(line)
   return '\n'.join(lines)
 
 

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -93,5 +93,12 @@ class CoreTest(testutils.BaseTestCase):
     error = core.FireError('Example error', 'value')
     self.assertIsNotNone(error)
 
+  def testPrintEmptyDict(self):
+    with self.assertStdoutMatches('{}'):
+      core.Fire(tc.EmptyDictOutput, 'totally_empty')
+    with self.assertStdoutMatches('{}'):
+      core.Fire(tc.EmptyDictOutput, 'nothing_printable')
+
+
 if __name__ == '__main__':
   testutils.main()

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -197,3 +197,11 @@ class NonComparable(object):
 
   def __ne__(self, other):
     raise ValueError('Instances of this class cannot be compared.')
+
+
+class EmptyDictOutput(object):
+  def totally_empty(self):
+    return {}
+
+  def nothing_printable(self):
+    return {'__do_not_print_me': 1}

--- a/fire/testutils.py
+++ b/fire/testutils.py
@@ -32,6 +32,15 @@ import six
 
 class BaseTestCase(unittest.TestCase):
   """Shared test case for Python Fire tests."""
+  @contextlib.contextmanager
+  def assertStdoutMatches(self, regexp):
+    """Asserts the context generates stdout matching regexp"""
+    stdout = six.StringIO()
+    with mock.patch.object(sys, 'stdout', stdout):
+      yield
+    value = stdout.getvalue()
+    if not re.search(regexp, value, re.DOTALL | re.MULTILINE):
+      raise AssertionError('Expected %r to match %r' % (value, regexp))
 
   @contextlib.contextmanager
   def assertRaisesFireExit(self, code, regexp=None):


### PR DESCRIPTION
Previously, outputs that generated dicts with all hidden keys would error with:

```
Traceback (most recent call last):
  File "/Users/jtratner/python-fire/fire/core_test.py", line 100, in testPrintEmptyDict
    core.Fire(tc.EmptyDictOutput, 'nothing_printable')
  File "/Users/jtratner/python-fire/fire/core.py", line 147, in Fire
    _PrintResult(component_trace, verbose=component_trace.verbose)
  File "/Users/jtratner/python-fire/fire/core.py", line 198, in _PrintResult
    print(_DictAsString(result, verbose))
  File "/Users/jtratner/python-fire/fire/core.py", line 221, in _DictAsString
    len(str(key)) for key in result.keys()
ValueError: max() arg is an empty sequence
```

This PR fixes that issue by filtering earlier in `_PrintResult` and adds a test case to cover the edge.

(I think I caught all the 2-spaces and lint errors this time haha)