### PR TITLE
Issue 42 : Handled exception of ValueError and added exception message in the output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Please see [The Python Fire Guide](doc/guide.md).
 | [Completion](doc/using-cli.md#completion-flag) | `command -- --completion` | Generate a completion script for the CLI.
 | [Trace](doc/using-cli.md#trace-flag) | `command -- --trace` | Gets a Fire trace for the command.
 | [Verbose](doc/using-cli.md#verbose-flag) | `command -- --verbose` |
+
 _Note that flags are separated from the Fire command by an isolated `--` arg._
 
 

--- a/fire/core.py
+++ b/fire/core.py
@@ -248,7 +248,9 @@ def _OneLineResult(result):
   try:
     return json.dumps(result)
   except (TypeError, ValueError) as e:
-      return "{value} [ Error:{error_message}]".format(value=str(result).replace('\n', ' '),error_message=str(e))
+    return "{value} [ Error:{error_message}]".format(value=str(result)
+                                                     .replace('\n', ' '),
+                                                     error_message=str(e))
 
 def _Fire(component, args, context, name=None):
   """Execute a Fire command on a target component using the args supplied.

--- a/fire/core.py
+++ b/fire/core.py
@@ -247,9 +247,8 @@ def _OneLineResult(result):
 
   try:
     return json.dumps(result)
-  except TypeError:
-    return str(result).replace('\n', ' ')
-
+  except (TypeError, ValueError) as e:
+      return "{value} [ Error:{error_message}]".format(value=str(result).replace('\n', ' '),error_message=str(e))
 
 def _Fire(component, args, context, name=None):
   """Execute a Fire command on a target component using the args supplied.

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -32,6 +32,13 @@ class CoreTest(testutils.BaseTestCase):
     self.assertEqual(core._OneLineResult('hello'), 'hello')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({}), '{}')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({'x': 'y'}), '{"x": "y"}')  # pylint: disable=protected-access
+    self.assertEqual(core._OneLineResult(self.createCircularRefObject()), "{'y': {...}} [ Error:Circular reference detected]")  # pylint: disable=protected-access
+
+  @staticmethod
+  def createCircularRefObject():
+    x={}
+    x['y']=x
+    return x
 
   @mock.patch('fire.interact.Embed')
   def testInteractiveMode(self, mock_embed):

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -32,12 +32,13 @@ class CoreTest(testutils.BaseTestCase):
     self.assertEqual(core._OneLineResult('hello'), 'hello')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({}), '{}')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({'x': 'y'}), '{"x": "y"}')  # pylint: disable=protected-access
-    self.assertEqual(core._OneLineResult(self.createCircularRefObject()), "{'y': {...}} [ Error:Circular reference detected]")  # pylint: disable=protected-access
+    self.assertEqual(core._OneLineResult(self.createCircularRefObject()),
+                     "{'y': {...}} [ Error:Circular reference detected]")  # pylint: disable=protected-access
 
   @staticmethod
   def createCircularRefObject():
-    x={}
-    x['y']=x
+    x = {}
+    x['y'] = x
     return x
 
   @mock.patch('fire.interact.Embed')


### PR DESCRIPTION
**Example:**

```
import fire
a="fire"
x = {}
x['y'] = x
fire.Fire()
```

**output:**

```
a:    fire
fire: <module 'fire' from '/Users/srpatel/github/python-fire/fire/__init__.pyc'> [ Error:<module 'fire' from '/Users/srpatel/github/python-fire/fire/__init__.pyc'> is not JSON serializable]
x:    {'y': {...}} [ Error:Circular reference detected]
```