### PR TITLE
Fixed Issue 42: Handled another type of exception and added testcase …

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -247,9 +247,8 @@ def _OneLineResult(result):
 
   try:
     return json.dumps(result)
-  except TypeError:
+  except (TypeError, ValueError):
     return str(result).replace('\n', ' ')
-
 
 def _Fire(component, args, context, name=None):
   """Execute a Fire command on a target component using the args supplied.

--- a/fire/core.py
+++ b/fire/core.py
@@ -250,6 +250,7 @@ def _OneLineResult(result):
   except (TypeError, ValueError):
     return str(result).replace('\n', ' ')
 
+
 def _Fire(component, args, context, name=None):
   """Execute a Fire command on a target component using the args supplied.
 

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -32,14 +32,12 @@ class CoreTest(testutils.BaseTestCase):
     self.assertEqual(core._OneLineResult('hello'), 'hello')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({}), '{}')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({'x': 'y'}), '{"x": "y"}')  # pylint: disable=protected-access
-    self.assertEqual(core._OneLineResult(self.createCircularRefObject()), # pylint: disable=protected-access
-                     "{'y': {...}}")
 
-  @staticmethod
-  def createCircularRefObject():
-    x = {}
-    x['y'] = x
-    return x
+
+  def testOneLineResultCircularRef(self):
+    circular_reference = tc.CircularReference()
+    self.assertEqual(core._OneLineResult(circular_reference.create()),# pylint: disable=protected-access
+                     "{'y': {...}}")
 
   @mock.patch('fire.interact.Embed')
   def testInteractiveMode(self, mock_embed):

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -36,7 +36,7 @@ class CoreTest(testutils.BaseTestCase):
 
   def testOneLineResultCircularRef(self):
     circular_reference = tc.CircularReference()
-    self.assertEqual(core._OneLineResult(circular_reference.create()),# pylint: disable=protected-access
+    self.assertEqual(core._OneLineResult(circular_reference.create()),  # pylint: disable=protected-access
                      "{'y': {...}}")
 
   @mock.patch('fire.interact.Embed')

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -32,6 +32,14 @@ class CoreTest(testutils.BaseTestCase):
     self.assertEqual(core._OneLineResult('hello'), 'hello')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({}), '{}')  # pylint: disable=protected-access
     self.assertEqual(core._OneLineResult({'x': 'y'}), '{"x": "y"}')  # pylint: disable=protected-access
+    self.assertEqual(core._OneLineResult(self.createCircularRefObject()), # pylint: disable=protected-access
+                     "{'y': {...}}")
+
+  @staticmethod
+  def createCircularRefObject():
+    x = {}
+    x['y'] = x
+    return x
 
   @mock.patch('fire.interact.Embed')
   def testInteractiveMode(self, mock_embed):

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -206,3 +206,11 @@ class EmptyDictOutput(object):
 
   def nothing_printable(self):
     return {'__do_not_print_me': 1}
+
+
+class CircularReference(object):
+
+  def create(self):
+    x = {}
+    x['y'] = x
+    return x


### PR DESCRIPTION
…for the same. I need help to resolve one pylint error

**After these changes:**

**Example:**

```
import fire
a="fire"
x = {}
x['y'] = x
fire.Fire()
```

**output:**

```
a:    fire
fire: <module 'fire' from '/Users/srpatel/github/python-fire/fire/__init__.pyc'> [ Error:<module 'fire' from '/Users/srpatel/github/python-fire/fire/__init__.pyc'> is not JSON serializable]
x:    {'y': {...}} 
```