### PR TITLE
ipython<6.0 for #57; fix broken links in guide.md

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -699,12 +699,12 @@ The complete set of flags available is shown below, in the reference section.
 
 | Using a CLI    | Command                    | Notes
 | :------------- | :------------------------- | :---------
-| [Help](doc/using-cli.md#help-flag) | `command -- --help` |Show help and usage information for the command.
-| [REPL](doc/using-cli.md#interactive-flag) | `command -- --interactive` | Enter interactive mode.
-| [Separator](doc/using-cli.md#separator-flag) | `command -- --separator=X` | This sets the separator to `X`. The default separator is `-`.
-| [Completion](doc/using-cli.md#completion-flag) | `command -- --completion` | Generate a completion script for the CLI.
-| [Trace](doc/using-cli.md#trace-flag) | `command -- --trace` | Gets a Fire trace for the command.
-| [Verbose](doc/using-cli.md#verbose-flag) | `command -- --verbose` | Include private members in the output.
+| [Help](using-cli.md#help-flag) | `command -- --help` |Show help and usage information for the command.
+| [REPL](using-cli.md#interactive-flag) | `command -- --interactive` | Enter interactive mode.
+| [Separator](using-cli.md#separator-flag) | `command -- --separator=X` | This sets the separator to `X`. The default separator is `-`.
+| [Completion](using-cli.md#completion-flag) | `command -- --completion` | Generate a completion script for the CLI.
+| [Trace](using-cli.md#trace-flag) | `command -- --trace` | Gets a Fire trace for the command.
+| [Verbose](using-cli.md#verbose-flag) | `command -- --verbose` | Include private members in the output.
 _Note that flags are separated from the Fire command by an isolated `--` arg._
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ SHORT_DESCRIPTION = """
 A library for automatically generating command line interfaces.""".strip()
 
 DEPENDENCIES = [
-    'ipython',
+    'ipython<6.0',
     'six',
 ]
 


### PR DESCRIPTION
As @jtratner notes, I'm not sure about the best way to address the travis CI issues.
But I just ran into that while fixing the broken links in guide.md.
