### PR TITLE
Simple implementation of allowing externally defined formatters

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -155,7 +155,7 @@ def Fire(component=None, command=None, name=None, formatter=None):
     raise FireExit(0, component_trace)
   else:
     result = component_trace.GetResult()
-    if formatter and args:
+    if formatter and args and '--' not in args:
       formatter(result)
     elif formatter and not args:
       print(helputils.HelpString(result, component_trace, component_trace.verbose))

--- a/fire/core.py
+++ b/fire/core.py
@@ -158,7 +158,7 @@ def Fire(component=None, command=None, name=None, formatter=None):
     if formatter and args:
       formatter(result)
     elif formatter and not args:
-      print(helputils.HelpString(result, component_trace, verbose))
+      print(helputils.HelpString(result, component_trace, component_trace.verbose))
     else:
       _PrintResult(component_trace, verbose=component_trace.verbose)
     return result

--- a/fire/core.py
+++ b/fire/core.py
@@ -85,6 +85,7 @@ def Fire(component=None, command=None, name=None, formatter=None):
         supplied, then the command is taken from sys.argv instead.
     name: Optional. The name of the command as entered at the command line.
         Used in interactive mode and for generating the completion script.
+    formatter: Optional. Function to be called for output formatting. (result object passed to formatter)
   Returns:
     The result of executing the Fire command. Execution begins with the initial
     target component. The component is updated by using the command arguments
@@ -153,11 +154,11 @@ def Fire(component=None, command=None, name=None, formatter=None):
         file=sys.stderr)
     raise FireExit(0, component_trace)
   else:
+    result = component_trace.GetResult()
     if formatter:
-      formatter(component_trace, verbose=component_trace.verbose)
+      formatter(result)
     else:
       _PrintResult(component_trace, verbose=component_trace.verbose)
-    result = component_trace.GetResult()
     return result
 
 

--- a/fire/core.py
+++ b/fire/core.py
@@ -155,8 +155,10 @@ def Fire(component=None, command=None, name=None, formatter=None):
     raise FireExit(0, component_trace)
   else:
     result = component_trace.GetResult()
-    if formatter:
+    if formatter and args:
       formatter(result)
+    elif formatter and not args:
+      print(helputils.HelpString(result, component_trace, verbose))
     else:
       _PrintResult(component_trace, verbose=component_trace.verbose)
     return result

--- a/fire/core.py
+++ b/fire/core.py
@@ -70,7 +70,7 @@ from fire import trace
 import six
 
 
-def Fire(component=None, command=None, name=None):
+def Fire(component=None, command=None, name=None, formatter=None):
   """This function, Fire, is the main entrypoint for Python Fire.
 
   Executes a command either from the `command` argument or from sys.argv by
@@ -153,7 +153,10 @@ def Fire(component=None, command=None, name=None):
         file=sys.stderr)
     raise FireExit(0, component_trace)
   else:
-    _PrintResult(component_trace, verbose=component_trace.verbose)
+    if formatter:
+      formatter(component_trace, verbose=component_trace.verbose)
+    else:
+      _PrintResult(component_trace, verbose=component_trace.verbose)
     result = component_trace.GetResult()
     return result
 

--- a/fire/helputils.py
+++ b/fire/helputils.py
@@ -23,6 +23,7 @@ from __future__ import division
 from __future__ import print_function
 
 import inspect
+import os
 
 from fire import completion
 from fire import inspectutils
@@ -113,12 +114,20 @@ def HelpString(component, trace=None, verbose=False):
   format_string = '{{field:{max_size}s}} {{value}}'.format(max_size=max_size)
 
   lines = []
+  source_filepath = None
   for field in fields:
     value = _DisplayValue(info, field, padding=max_size + 1)
+    if field == 'file':
+      source_filepath = value  # assumes that 'file' comes before usage (See 'fields' above)
     if value:
       if lines and field == 'usage':
         lines.append('')  # Ensure a blank line before usage.
 
+        # use package_name if file called is __main__.py
+        if source_filepath and source_filepath.endswith('__main__.py'):
+          package_path, _ = os.path.split(source_filepath)
+          _, package_name = os.path.split(package_path)
+          value = value.replace('__main__.py', package_name)
       lines.append(format_string.format(
           field=_NormalizeField(field) + ':',
           value=value,

--- a/fire/helputils.py
+++ b/fire/helputils.py
@@ -106,7 +106,15 @@ def HelpString(component, trace=None, verbose=False):
 
       'usage',
   ]
+  display_fields = [
+      'docstring',
+      'init_docstring',
+      'class_docstring',
+      'call_docstring',
+      'length',
 
+      'usage',
+  ]
   max_size = max(
       len(_NormalizeField(field)) + 1
       for field in fields
@@ -119,7 +127,7 @@ def HelpString(component, trace=None, verbose=False):
     value = _DisplayValue(info, field, padding=max_size + 1)
     if field == 'file':
       source_filepath = value  # assumes that 'file' comes before usage (See 'fields' above)
-    if value:
+    if value and field in display_fields:
       if lines and field == 'usage':
         lines.append('')  # Ensure a blank line before usage.
 


### PR DESCRIPTION
I noticed there is a TODO in `_PrintResult` to provide better handling of output formatting, but this is a quick an easy way to allow end-users to provide their own defined formatters.

For your consideration.

In response to raised issue #74 