### PR TITLE
Include LICENSE file in the output of "python setup.py sdist".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,4 +81,5 @@ setup(
 
     install_requires=DEPENDENCIES,
     tests_require=TEST_DEPENDENCIES,
+    data_files=[("", ["LICENSE"])],
 )


### PR DESCRIPTION
This is for issue #81.
Adds the LICENSE file to the release.

Note to future self: an alternative approach would be to use a MANIFEST.in file as in the https://github.com/python-attrs/attrs repo.
