### PR TITLE
Fix for BinOp in args

### DIFF
--- a/fire/parser.py
+++ b/fire/parser.py
@@ -94,6 +94,9 @@ def _LiteralEval(value):
     SyntaxError: If the value string has a syntax error.
   """
   root = ast.parse(value, mode='eval')
+  if isinstance(root.body, ast.BinOp):
+    return value
+  
   for node in ast.walk(root):
     for field, child in ast.iter_fields(node):
       if isinstance(child, list):

--- a/fire/parser.py
+++ b/fire/parser.py
@@ -95,7 +95,7 @@ def _LiteralEval(value):
   """
   root = ast.parse(value, mode='eval')
   if isinstance(root.body, ast.BinOp):
-    return value
+    raise ValueError(value)
 
   for node in ast.walk(root):
     for field, child in ast.iter_fields(node):

--- a/fire/parser.py
+++ b/fire/parser.py
@@ -96,7 +96,7 @@ def _LiteralEval(value):
   root = ast.parse(value, mode='eval')
   if isinstance(root.body, ast.BinOp):
     return value
-  
+
   for node in ast.walk(root):
     for field, child in ast.iter_fields(node):
       if isinstance(child, list):

--- a/fire/parser_test.py
+++ b/fire/parser_test.py
@@ -127,13 +127,15 @@ class ParserTest(testutils.BaseTestCase):
     # If it can't be parsed, we treat it as a string. This behavior may change.
     self.assertEqual(
         parser.DefaultParseValue('[(A, 2, "3"), 5'), '[(A, 2, "3"), 5')
-
     self.assertEqual(parser.DefaultParseValue('x=10'), 'x=10')
 
   def testDefaultParseValueSyntaxError(self):
     # If it can't be parsed, we treat it as a string.
     self.assertEqual(parser.DefaultParseValue('"'), '"')
 
+  def testDefaultParseValueIgnoreBinOp(self):
+    self.assertEqual(parser.DefaultParseValue('2017-10-10'), '2017-10-10')
+    self.assertEqual(parser.DefaultParseValue('1+1'), '1+1')
 
 if __name__ == '__main__':
   testutils.main()

--- a/fire/parser_test.py
+++ b/fire/parser_test.py
@@ -69,10 +69,12 @@ class ParserTest(testutils.BaseTestCase):
 
   def testDefaultParseValueNumbers(self):
     self.assertEqual(parser.DefaultParseValue('23'), 23)
+    self.assertEqual(parser.DefaultParseValue('-23'), -23)
     self.assertEqual(parser.DefaultParseValue('23.0'), 23.0)
     self.assertIsInstance(parser.DefaultParseValue('23'), int)
     self.assertIsInstance(parser.DefaultParseValue('23.0'), float)
     self.assertEqual(parser.DefaultParseValue('23.5'), 23.5)
+    self.assertEqual(parser.DefaultParseValue('-23.5'), -23.5)
 
   def testDefaultParseValueStringNumbers(self):
     self.assertEqual(parser.DefaultParseValue("'23'"), '23')


### PR DESCRIPTION
Fixes #95
Don't evaluate top level ast.BinOp arguments, treat them as strings instead.