### PR TITLE
Support for a flag to inject environment variables

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -570,13 +570,13 @@ def _MakeParseFn(fn, use_environment=None):
 
     # Enrich with environment variables
     if use_environment is not None:
-        for arg in fn_spec.args[len(remaining_args):]:
-            env_var_name = use_environment + arg
-            env_var_name_upper = use_environment + arg.upper()
-            env_value = os.environ.get(env_var_name,
-                                       os.environ.get(env_var_name_upper))
-            if arg not in kwargs and env_value:
-                kwargs[arg] = env_value
+      for arg in fn_spec.args[len(remaining_args):]:
+        env_var_name = use_environment + arg
+        env_var_name_upper = use_environment + arg.upper()
+        env_value = os.environ.get(env_var_name,
+                                   os.environ.get(env_var_name_upper))
+        if arg not in kwargs and env_value:
+          kwargs[arg] = env_value
 
     # Note: _ParseArgs modifies kwargs.
     parsed_args, kwargs, remaining_args, capacity = _ParseArgs(

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+
 from fire import core
 from fire import test_components as tc
 from fire import testutils
@@ -71,6 +73,24 @@ class CoreTest(testutils.BaseTestCase):
     self.assertIsInstance(variables['self'], tc.WithDefaults)
     self.assertEqual(variables['D'], tc.WithDefaults)
     self.assertIsInstance(variables['trace'], trace.FireTrace)
+
+  def testUsingEnvironment(self):
+    os.environ['count'] = '4'
+    res = core.Fire(tc.WithDefaults,
+                    command=['double', '--', '--use_environment'])
+    assert res == 8
+
+  def testUsingEnvironmentDefaultsToUpper(self):
+    os.environ['COUNT'] = '4'
+    res = core.Fire(tc.WithDefaults,
+                    command=['double', '--', '--use_environment'])
+    assert res == 8
+
+  def testUsingEnvironmentNamespaced(self):
+    os.environ['TEST_NS_count'] = '5'
+    res = core.Fire(tc.WithDefaults,
+                    command=['double', '--', '--use_environment', 'TEST_NS_'])
+    assert res == 10
 
   def testImproperUseOfHelp(self):
     # This should produce a warning explaining the proper use of help.

--- a/fire/parser.py
+++ b/fire/parser.py
@@ -23,6 +23,12 @@ import ast
 
 
 def CreateParser():
+  """Creates the parser for the flags for Python fire
+
+  Returns:
+    An instance of argparse.ArgumentParser with the flags already added.
+
+  """
   parser = argparse.ArgumentParser(add_help=False)
   parser.add_argument('--verbose', '-v', action='store_true')
   parser.add_argument('--interactive', '-i', action='store_true')

--- a/fire/parser.py
+++ b/fire/parser.py
@@ -30,6 +30,7 @@ def CreateParser():
   parser.add_argument('--completion', action='store_true')
   parser.add_argument('--help', '-h', action='store_true')
   parser.add_argument('--trace', '-t', action='store_true')
+  parser.add_argument('--use_environment', nargs='?', default=None, const='')
   # TODO: Consider allowing name to be passed as an argument.
   return parser
 


### PR DESCRIPTION
Add a new option that will take defaults from environment variables if available.

The variable is looked up as the parameter and full uppercase for convenience.

The option use_environment can be used both as a flag or a value can be passed in which allows to set a prefix for the env variables to look for. (Check the tests)

I'm not totally convinced on how the variable is passed around the code. Open to suggestions.

Happy to add docs once we finalise all decisions.

Fixes #94 