### PR TITLE
Allow using fire without editing code directly.

### DIFF
--- a/fire/__main__.py
+++ b/fire/__main__.py
@@ -1,0 +1,16 @@
+"""
+Module for running python fire as a "main" function and thereby allowing using
+fire with other programs.
+"""
+import importlib
+import sys
+
+import fire
+
+def main():
+  module_name = sys.argv[1]
+  module = importlib.import_module(module_name)
+  fire.Fire(module, name=module_name, command=sys.argv[2:])
+
+if __name__ == '__main__':
+  main()

--- a/fire/__main__.py
+++ b/fire/__main__.py
@@ -1,16 +1,18 @@
-"""
-Module for running python fire as a "main" function and thereby allowing using
-fire with other programs.
+"""Run python as a "main" function (i.e., ``python -m fire``)
+
+This allows using fire in other libraries without modifying their code.
 """
 import importlib
 import sys
 
 import fire
 
+
 def main(args):
   module_name = args[1]
   module = importlib.import_module(module_name)
   fire.Fire(module, name=module_name, command=args[2:])
+
 
 if __name__ == '__main__':
   main(sys.argv)

--- a/fire/__main__.py
+++ b/fire/__main__.py
@@ -7,10 +7,10 @@ import sys
 
 import fire
 
-def main():
-  module_name = sys.argv[1]
+def main(args):
+  module_name = args[1]
   module = importlib.import_module(module_name)
-  fire.Fire(module, name=module_name, command=sys.argv[2:])
+  fire.Fire(module, name=module_name, command=args[2:])
 
 if __name__ == '__main__':
-  main()
+  main(sys.argv)

--- a/fire/test_main.py
+++ b/fire/test_main.py
@@ -9,7 +9,6 @@ from fire import testutils
 class TestAsMainModule(testutils.BaseTestCase):
   def test_name_setting(self):
     # confirm one of the usage lines has tempfile gettempdir
-    # with self.assertRaisesFireExit(2, 'tempfile gettempdir'):
     with self.assertOutputMatches('tempfile gettempdir'):
       __main__.main(['__main__.py', 'tempfile'])
   def test_arg_passing(self):

--- a/fire/test_main.py
+++ b/fire/test_main.py
@@ -4,7 +4,6 @@ Test using fire via python -m fire
 import os
 
 from fire import __main__
-from fire.core import FireExit
 from fire import testutils
 
 class TestAsMainModule(testutils.BaseTestCase):
@@ -12,12 +11,7 @@ class TestAsMainModule(testutils.BaseTestCase):
     # confirm one of the usage lines has tempfile gettempdir
     # with self.assertRaisesFireExit(2, 'tempfile gettempdir'):
     with self.assertOutputMatches('tempfile gettempdir'):
-      try:
-        __main__.main(['__main__.py', 'tempfile'])
-      except FireExit as e:
-        self.assertEqual(e.trace.name, 'tempfile')
-        raise
-      assert False, 'should have raised FireExit'
+      __main__.main(['__main__.py', 'tempfile'])
   def test_arg_passing(self):
     expected = os.path.join('part1', 'part2', 'part3')
     with self.assertOutputMatches('%s\n' % expected):

--- a/fire/test_main.py
+++ b/fire/test_main.py
@@ -6,12 +6,14 @@ import os
 from fire import __main__
 from fire import testutils
 
-class TestAsMainModule(testutils.BaseTestCase):
-  def test_name_setting(self):
+
+class MainModuleTest(testutils.BaseTestCase):
+  def testNameSetting(self):
     # confirm one of the usage lines has tempfile gettempdir
     with self.assertOutputMatches('tempfile gettempdir'):
       __main__.main(['__main__.py', 'tempfile'])
-  def test_arg_passing(self):
+
+  def testArgPassing(self):
     expected = os.path.join('part1', 'part2', 'part3')
     with self.assertOutputMatches('%s\n' % expected):
       __main__.main(['__main__.py', 'os.path', 'join', 'part1', 'part2',

--- a/fire/test_main.py
+++ b/fire/test_main.py
@@ -1,6 +1,4 @@
-"""
-Test using fire via python -m fire
-"""
+"""Test using fire via python -m fire"""
 import os
 
 from fire import __main__

--- a/fire/test_main.py
+++ b/fire/test_main.py
@@ -1,0 +1,25 @@
+"""
+Test using fire via python -m fire
+"""
+import os
+
+from fire import __main__
+from fire.core import FireExit
+from fire import testutils
+
+class TestAsMainModule(testutils.BaseTestCase):
+  def test_name_setting(self):
+    # confirm one of the usage lines has tempfile gettempdir
+    # with self.assertRaisesFireExit(2, 'tempfile gettempdir'):
+    with self.assertOutputMatches('tempfile gettempdir'):
+      try:
+        __main__.main(['__main__.py', 'tempfile'])
+      except FireExit as e:
+        self.assertEqual(e.component_trace.name, 'tempfile')
+        raise
+  def test_arg_passing(self):
+    expected = os.path.join('part1', 'part2', 'part3')
+    with self.assertOutputMatches('%s\n' % expected):
+      __main__.main(['__main__.py', 'os.path', 'join', 'part1', 'part2', 'part3'])
+    with self.assertOutputMatches('%s\n' % expected):
+      __main__.main(['__Main__.py', 'os', 'path', '-', 'join', 'part1', 'part2', 'part3'])

--- a/fire/test_main.py
+++ b/fire/test_main.py
@@ -15,8 +15,9 @@ class TestAsMainModule(testutils.BaseTestCase):
       try:
         __main__.main(['__main__.py', 'tempfile'])
       except FireExit as e:
-        self.assertEqual(e.component_trace.name, 'tempfile')
+        self.assertEqual(e.trace.name, 'tempfile')
         raise
+      assert False, 'should have raised FireExit'
   def test_arg_passing(self):
     expected = os.path.join('part1', 'part2', 'part3')
     with self.assertOutputMatches('%s\n' % expected):

--- a/fire/test_main.py
+++ b/fire/test_main.py
@@ -20,6 +20,8 @@ class TestAsMainModule(testutils.BaseTestCase):
   def test_arg_passing(self):
     expected = os.path.join('part1', 'part2', 'part3')
     with self.assertOutputMatches('%s\n' % expected):
-      __main__.main(['__main__.py', 'os.path', 'join', 'part1', 'part2', 'part3'])
+      __main__.main(['__main__.py', 'os.path', 'join', 'part1', 'part2',
+                     'part3'])
     with self.assertOutputMatches('%s\n' % expected):
-      __main__.main(['__Main__.py', 'os', 'path', '-', 'join', 'part1', 'part2', 'part3'])
+      __main__.main(['__main__.py', 'os', 'path', '-', 'join', 'part1',
+                     'part2', 'part3'])


### PR DESCRIPTION
Enable `python -m fire <module> <args>` to work - closes #29. @dbieber 

I wanted to restart the discussion in #29 with a *very* simple implementation that doesn't lock us into any advanced functionality at all.  Everything else works exactly the same, except that you prefix with `python -m fire` and the first argument must resolve to a module. 

### `python -m fire` vs. `fire`

I used `python -m fire` rather than an external `fire` tool, because it's really important that the python interpreter be exactly the same, and this avoids confusing bugs where `fire` resolves to something in the global environment, but you're trying to test something in a virtualenv or conda environment.

### Testing

I need to think a little bit about how to test running fire with `-m` (I'm sure someone on the internet knows) but I'd like to get feedback on whether this a good implementation before investing too much time there.

### "Bugs"

* `--interactive` currently jumps you into a shell with the specified module loaded, rather than what you might expect (`from <module> import *`)

### Examples


```
$ python -m fire tempfile mkdtemp
/var/folders/fm/sjgpzb856kld04jvq82bxrcw0000gp/T/tmpCbfg_1
```

or

```
$ python -m fire urllib unquote genetics%3Dawesome%26editor%3Dcrispr
genetics=awesome&editor=crispr
```

This follows normal python import semantics, so if you have a script
file, it'll work if named just as a module:

```
# myscript.py
def fn1(x, y):
    return x
```

```
$ python -m fire myscript 5 6
5
```


### Why manipulate sys.argv?

1. when running with `-m`, nothing else is going to be pulling from sys.argv
2. it makes for a nicer help text (rather than `__main__.py` you can show the module)

```
›› python -m fire base64
Type:        module
String form: <module 'base64' from '/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/base64.pyc'>
File:        /usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/base64.py
Line:        1
Docstring:   RFC 3548: Base16, Base32, Base64 Data Encodings

Usage:       base64
             base64 EMPTYSTRING
             base64 MAXBINSIZE
             base64 MAXLINESIZE
             base64 b16decode
             base64 b16encode
             base64 b32decode
             base64 b32encode
             base64 b64decode
             base64 b64encode
             base64 binascii
             base64 decode
             base64 decodestring
             base64 encode
             base64 encodestring
             base64 k
             base64 re
             base64 standard-b64decode
             base64 standard-b64encode
             base64 string
             base64 struct
             base64 test
             base64 test1
             base64 urlsafe-b64decode
             base64 urlsafe-b64encode
             base64 v
```