### PR TITLE
unicode() --> six.u() for Python 3 compatibility

### DIFF
--- a/fire/parser_fuzz_test.py
+++ b/fire/parser_fuzz_test.py
@@ -67,8 +67,8 @@ class ParserFuzzTest(testutils.BaseTestCase):
       raise
 
     try:
-      uvalue = unicode(value)
-      uresult = unicode(result)
+      uvalue = six.u(value)
+      uresult = six.u(result)
     except UnicodeDecodeError:
       # This is not what we're testing.
       return


### PR DESCRIPTION
__unicode()__ was removed from Python 3 because all strs are unicode.

Executing these lines in Python 3 would raise a NameError.

* https://pythonhosted.org/six/#six.u