### PR TITLE
Fixes bug setting stories in guide.md

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -461,13 +461,13 @@ class Building(object):
 
   def __init__(self, name, stories=1):
     self.name = name
-    self.stories = 1
+    self.stories = stories
 
   def climb_stairs(self, stairs_per_story=10):
     for story in range(self.stories):
       for stair in range(1, stairs_per_story):
         yield stair
-        yield 'Phew!'
+      yield 'Phew!'
     yield 'Done!'
 
 if __name__ == '__main__':


### PR DESCRIPTION
The example wass slightly broken, and always sets stories=1. Also changed the phew to be after a whole floor instead of every single step.