### PR TITLE
Fix several warnings in the diff example

### DIFF
--- a/examples/diff/diff.py
+++ b/examples/diff/diff.py
@@ -74,9 +74,9 @@ class DiffLibWrapper(object):
 
     self.fromdate = time.ctime(os.stat(fromfile).st_mtime)
     self.todate = time.ctime(os.stat(tofile).st_mtime)
-    with open(fromfile, 'U') as f:
+    with open(fromfile) as f:
       self.fromlines = f.readlines()
-    with open(tofile, 'U') as f:
+    with open(tofile) as f:
       self.tolines = f.readlines()
 
   def unified_diff(self, lines=3):


### PR DESCRIPTION
Fixes ResourceWarning unclosed file:
```python
examples/diff/diff.py:78: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/tmpnby8pemm' mode='U' encoding='UTF-8'>
    self.tolines = open(tofile, 'U').readlines()
```
And DeprecationWarning 'U' mode is deprecated:
```python
examples/diff/diff_test.py::DiffTest::testUnifiedDiff
  examples/diff/diff.py:77: DeprecationWarning: 'U' mode is deprecated
    with open(fromfile, 'U') as f:
```