### PR TITLE
Issue #108: Shortcuts for boolean arguments

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -60,6 +60,7 @@ import pipes
 import shlex
 import sys
 import types
+import re
 
 from fire import completion
 from fire import decorators
@@ -750,7 +751,7 @@ def _ParseArgs(fn_args, fn_defaults, num_required_args, kwargs,
 def _ParseKeywordArgs(args, fn_spec):
   """Parses the supplied arguments for keyword arguments.
 
-  Given a list of arguments, finds occurences of --name value, and uses 'name'
+  Given a list of arguments, finds occurrences of --name value, and uses 'name'
   as the keyword and 'value' as the value. Constructs and returns a dictionary
   of these keyword arguments, and returns a list of the remaining arguments.
 
@@ -767,6 +768,9 @@ def _ParseKeywordArgs(args, fn_spec):
     kwargs: A dictionary mapping keywords to values.
     remaining_kwargs: A list of the unused kwargs from the original args.
     remaining_args: A list of the unused arguments from the original args.
+  Raises:
+    FireError: if a boolean shortcut arg is passed that could refer to multiple
+        args
   """
   kwargs = {}
   remaining_kwargs = []
@@ -793,7 +797,7 @@ def _ParseKeywordArgs(args, fn_spec):
       contains_equals = '=' in keyword
       is_bool_syntax = (
           not contains_equals and
-          (index + 1 == len(args) or args[index + 1].startswith('--')))
+          (index + 1 == len(args) or args[index + 1].startswith('--') or re.match('^\-[a-z]$', args[index + 1])))
       if contains_equals:
         keyword, value = keyword.split('=', 1)
         got_argument = True
@@ -827,6 +831,16 @@ def _ParseKeywordArgs(args, fn_spec):
           remaining_kwargs.append(argument)
           if skip_argument:
             remaining_kwargs.append(args[index + 1])
+
+    # catch boolean shortcut args
+    elif re.match('^\-[a-z]$',argument):
+      keychar = argument[1]
+      potential_args = [arg for arg in fn_args if arg[0] == keychar]
+      if len(potential_args) == 1:
+        arg_consumed = True
+        kwargs[potential_args[0]] = 'True'
+      elif len(potential_args) > 1:
+        raise FireError("The argument '{}' is ambiguous as it could refer to any of the following arguments: {}".format(argument, potential_args))
 
     if not arg_consumed:
       # The argument was not consumed, so it is still a remaining argument.

--- a/fire/core.py
+++ b/fire/core.py
@@ -802,7 +802,7 @@ def _ParseKeywordArgs(args, fn_spec):
         elif len(potential_args) > 1:
           raise FireError("The argument '{}' is ambiguous as it could "
                           "refer to any of the following arguments: {}".format(
-            argument, potential_args))
+                              argument, potential_args))
 
       else:
         keyword = argument[2:]

--- a/fire/core.py
+++ b/fire/core.py
@@ -795,9 +795,10 @@ def _ParseKeywordArgs(args, fn_spec):
 
       keyword = argument[2:]
       contains_equals = '=' in keyword
-      is_bool_syntax = (
-          not contains_equals and
-          (index + 1 == len(args) or args[index + 1].startswith('--') or re.match('^\-[a-z]$', args[index + 1])))
+      is_bool_syntax = (not contains_equals and
+                        (index + 1 == len(args) or
+                        args[index + 1].startswith('--') or
+                        re.match('^\-[a-z]$', args[index + 1])))
       if contains_equals:
         keyword, value = keyword.split('=', 1)
         got_argument = True
@@ -840,7 +841,9 @@ def _ParseKeywordArgs(args, fn_spec):
         arg_consumed = True
         kwargs[potential_args[0]] = 'True'
       elif len(potential_args) > 1:
-        raise FireError("The argument '{}' is ambiguous as it could refer to any of the following arguments: {}".format(argument, potential_args))
+        raise FireError("The argument '{}' is ambiguous as it could "
+                        "refer to any of the following arguments: {}".format(
+                        argument, potential_args))
 
     if not arg_consumed:
       # The argument was not consumed, so it is still a remaining argument.

--- a/fire/core.py
+++ b/fire/core.py
@@ -797,8 +797,8 @@ def _ParseKeywordArgs(args, fn_spec):
       contains_equals = '=' in keyword
       is_bool_syntax = (not contains_equals and
                         (index + 1 == len(args) or
-                        args[index + 1].startswith('--') or
-                        re.match('^-[a-z]$', args[index + 1])))
+                         args[index + 1].startswith('--') or
+                         re.match('^-[a-z]$', args[index + 1])))
       if contains_equals:
         keyword, value = keyword.split('=', 1)
         got_argument = True

--- a/fire/core.py
+++ b/fire/core.py
@@ -851,15 +851,19 @@ def _ParseKeywordArgs(args, fn_spec):
 
   return kwargs, remaining_kwargs, remaining_args
 
+
 def _IsFlag(argument):
+  """Determines if the argument is a flag argument"""
   return _IsSingleCharFlag(argument) or _IsMultiCharFlag(argument)
 
 
 def _IsSingleCharFlag(argument):
+  """Determines if the argument is a single char flag (e.g. '-a')"""
   return re.match('^-[a-z]$', argument)
 
 
 def _IsMultiCharFlag(argument):
+  """Determines if the argument is a multi char flag (e.g. '-alpha')"""
   return argument.startswith('--')
 
 

--- a/fire/core.py
+++ b/fire/core.py
@@ -863,7 +863,7 @@ def _IsSingleCharFlag(argument):
 
 
 def _IsMultiCharFlag(argument):
-  """Determines if the argument is a multi char flag (e.g. '-alpha')"""
+  """Determines if the argument is a multi char flag (e.g. '--alpha')"""
   return argument.startswith('--')
 
 

--- a/fire/core.py
+++ b/fire/core.py
@@ -789,16 +789,27 @@ def _ParseKeywordArgs(args, fn_spec):
       continue
 
     arg_consumed = False
-    if argument.startswith('--'):
+    if _IsFlag(argument):
       # This is a named argument; get its value from this arg or the next.
       got_argument = False
 
-      keyword = argument[2:]
+      keyword = ''
+      if _IsSingleCharFlag(argument):
+        keychar = argument[1]
+        potential_args = [arg for arg in fn_args if arg[0] == keychar]
+        if len(potential_args) == 1:
+          keyword = potential_args[0]
+        elif len(potential_args) > 1:
+          raise FireError("The argument '{}' is ambiguous as it could "
+                          "refer to any of the following arguments: {}".format(
+            argument, potential_args))
+
+      else:
+        keyword = argument[2:]
+
       contains_equals = '=' in keyword
       is_bool_syntax = (not contains_equals and
-                        (index + 1 == len(args) or
-                         args[index + 1].startswith('--') or
-                         re.match('^-[a-z]$', args[index + 1])))
+                        (index + 1 == len(args) or _IsFlag(args[index + 1])))
       if contains_equals:
         keyword, value = keyword.split('=', 1)
         got_argument = True
@@ -833,23 +844,23 @@ def _ParseKeywordArgs(args, fn_spec):
           if skip_argument:
             remaining_kwargs.append(args[index + 1])
 
-    # catch boolean shortcut args
-    elif re.match('^-[a-z]$', argument):
-      keychar = argument[1]
-      potential_args = [arg for arg in fn_args if arg[0] == keychar]
-      if len(potential_args) == 1:
-        arg_consumed = True
-        kwargs[potential_args[0]] = 'True'
-      elif len(potential_args) > 1:
-        raise FireError("The argument '{}' is ambiguous as it could "
-                        "refer to any of the following arguments: {}".format(
-                            argument, potential_args))
 
     if not arg_consumed:
       # The argument was not consumed, so it is still a remaining argument.
       remaining_args.append(argument)
 
   return kwargs, remaining_kwargs, remaining_args
+
+def _IsFlag(argument):
+  return _IsSingleCharFlag(argument) or _IsMultiCharFlag(argument)
+
+
+def _IsSingleCharFlag(argument):
+  return re.match('^-[a-z]$', argument)
+
+
+def _IsMultiCharFlag(argument):
+  return argument.startswith('--')
 
 
 def _ParseValue(value, index, arg, metadata):

--- a/fire/core.py
+++ b/fire/core.py
@@ -798,7 +798,7 @@ def _ParseKeywordArgs(args, fn_spec):
       is_bool_syntax = (not contains_equals and
                         (index + 1 == len(args) or
                         args[index + 1].startswith('--') or
-                        re.match('^\-[a-z]$', args[index + 1])))
+                        re.match('^-[a-z]$', args[index + 1])))
       if contains_equals:
         keyword, value = keyword.split('=', 1)
         got_argument = True
@@ -834,7 +834,7 @@ def _ParseKeywordArgs(args, fn_spec):
             remaining_kwargs.append(args[index + 1])
 
     # catch boolean shortcut args
-    elif re.match('^\-[a-z]$',argument):
+    elif re.match('^-[a-z]$', argument):
       keychar = argument[1]
       potential_args = [arg for arg in fn_args if arg[0] == keychar]
       if len(potential_args) == 1:
@@ -843,7 +843,7 @@ def _ParseKeywordArgs(args, fn_spec):
       elif len(potential_args) > 1:
         raise FireError("The argument '{}' is ambiguous as it could "
                         "refer to any of the following arguments: {}".format(
-                        argument, potential_args))
+                            argument, potential_args))
 
     if not arg_consumed:
       # The argument was not consumed, so it is still a remaining argument.

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -385,6 +385,21 @@ class FireTest(testutils.BaseTestCase):
         fire.Fire(tc.MixedDefaults, command=r'identity --alpha \"--test\"'),
         ('--test', '0'))
 
+  def testBoolShortcutParsing(self):
+    self.assertEqual(
+        fire.Fire(tc.MixedDefaults,
+                  command=['identity', '-a']), (True, '0'))
+    self.assertEqual(
+        fire.Fire(tc.MixedDefaults,
+                  command=['identity', '-a', '--beta=10']), (True, 10))
+    self.assertEqual(
+        fire.Fire(tc.MixedDefaults,
+                  command=['identity', '-a', '-b']), (True, True))
+    with self.assertRaisesFireExit(2):
+      # This test attempts to use a boolean shortcut on a function with
+      # a naming conflict for the shortcut, triggering a FireError
+      fire.Fire(tc.SimilarArgNames, command=['identity', '-b'])
+
   def testBoolParsingWithNo(self):
     # In these examples --nothing always refers to the nothing argument:
     def fn1(thing, nothing):

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -395,6 +395,15 @@ class FireTest(testutils.BaseTestCase):
     self.assertEqual(
         fire.Fire(tc.MixedDefaults,
                   command=['identity', '-a', '-b']), (True, True))
+    self.assertEqual(
+      fire.Fire(tc.MixedDefaults,
+                  command=['identity', '-a', '42', '-b']), (42, True))
+    self.assertEqual(
+      fire.Fire(tc.MixedDefaults,
+                  command=['identity', '-a', '42', '-b', '10']), (42, 10))
+    self.assertEqual(
+      fire.Fire(tc.MixedDefaults,
+                  command=['identity', '--alpha', 'True', '-b', '10']), (True, 10))
     with self.assertRaisesFireExit(2):
       # This test attempts to use a boolean shortcut on a function with
       # a naming conflict for the shortcut, triggering a FireError

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -403,7 +403,8 @@ class FireTest(testutils.BaseTestCase):
                   command=['identity', '-a', '42', '-b', '10']), (42, 10))
     self.assertEqual(
         fire.Fire(tc.MixedDefaults,
-                  command=['identity', '--alpha', 'True', '-b', '10']), (True, 10))
+                  command=['identity', '--alpha', 'True', '-b', '10']),
+        (True, 10))
     with self.assertRaisesFireExit(2):
       # This test attempts to use a boolean shortcut on a function with
       # a naming conflict for the shortcut, triggering a FireError

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -396,13 +396,13 @@ class FireTest(testutils.BaseTestCase):
         fire.Fire(tc.MixedDefaults,
                   command=['identity', '-a', '-b']), (True, True))
     self.assertEqual(
-      fire.Fire(tc.MixedDefaults,
+        fire.Fire(tc.MixedDefaults,
                   command=['identity', '-a', '42', '-b']), (42, True))
     self.assertEqual(
-      fire.Fire(tc.MixedDefaults,
+        fire.Fire(tc.MixedDefaults,
                   command=['identity', '-a', '42', '-b', '10']), (42, 10))
     self.assertEqual(
-      fire.Fire(tc.MixedDefaults,
+        fire.Fire(tc.MixedDefaults,
                   command=['identity', '--alpha', 'True', '-b', '10']), (True, 10))
     with self.assertRaisesFireExit(2):
       # This test attempts to use a boolean shortcut on a function with

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -104,6 +104,12 @@ class MixedDefaults(object):
     return alpha, beta
 
 
+class SimilarArgNames(object):
+
+  def identity(self, bool_one=False, bool_two=False):
+    return bool_one, bool_two
+
+
 class Annotations(object):
 
   def double(self, count=0):


### PR DESCRIPTION
In response to [this issue](https://github.com/google/python-fire/issues/108).  This adds a feature where a shortcut can be used for boolean arguments of functions.  For example the function

`def foo(bar=False):`

can be invoked as `foo -b` to set bar to True.  While developing this, I came across a couple concerns:

- In detecting whether or not arguments matched the pattern of a bool shortcut, I decided that python's regex library was the best way to solve this problem.  Is adding `re` to imports ok?
- If a naming collision occurs (see final assert of `testBoolShortcutParsing`) the program raises a FireError describing the ambiguity.  Is this a proper manner to use this error in?
- Currently, if a shortcut doesn't match any function argument, it is parsed as-is.  Should something else be done in this scenario?