### PR TITLE
Completion Enhancements

### DIFF
--- a/fire/completion.py
+++ b/fire/completion.py
@@ -450,9 +450,9 @@ def _GetMaps(name, commands, default_options):
     options_map: A dict storing set of options for each subcommand.
   """
 
-  global_options = copy(default_options)
-  options_map = defaultdict(lambda: copy(default_options))
-  subcommands_map = defaultdict(set())
+  global_options = copy.copy(default_options)
+  options_map = collections.defaultdict(lambda: copy.copy(default_options))
+  subcommands_map = collections.defaultdict(set)
 
   for command in commands:
     if len(command) == 1:

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -165,7 +165,7 @@ complete -F _complete-{identifier} {command}
         )),
       ),
     )
-    for command in subcommands_map.keys() + options_map.keys()
+    for command in set(subcommands_map.keys()).union(set(options_map.keys()))
   )
 
   checks = check_wrapper.format(
@@ -255,7 +255,7 @@ end
                    " -l {option}\n")
 
   prev_global_check = " and __is_prev_global;"
-  for command in subcommands_map.keys() + options_map.keys():
+  for command in set(subcommands_map.keys()).union(set(options_map.keys())):
     for subcommand in subcommands_map[command]:
       fish_source += subcommand_template.format(
         name=name,

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -46,31 +46,11 @@ def _BashScript(name, commands, default_options=None):
     A string which is the Bash script. Source the bash script to enable tab
     completion in Bash.
   """
+
   default_options = default_options or set()
-  global_options = copy(default_options)
-  options_map = defaultdict(lambda: copy(default_options))
-  subcommands_map = defaultdict(lambda: set())
-
-  for command in commands:
-    if len(command) == 1:
-
-      if _isOption(command[0]):
-        global_options.add(command[0])
-      else:
-        subcommands_map[name].add(command[0])
-
-    elif len(command) != 0:
-
-      subcommand = command[-2]
-      arg = _FormatForCommand(command[-1])
-
-      if _isOption(arg):
-        args_map = options_map
-      else:
-        args_map = subcommands_map
-
-      args_map[subcommand].add(arg)
-      args_map[subcommand.replace('_', '-')].add(arg)
+  global_options, options_map, subcommands_map = _GetMaps(
+    name, commands, default_options
+  )
 
   bash_completion_template = """# bash completion support for {name}
 # DO NOT EDIT.
@@ -353,3 +333,31 @@ def _Commands(component, depth=3):
 
 def _isOption(arg):
   return arg.startswith('-')
+
+def _GetMaps(name, commands, default_options):
+  global_options = copy(default_options)
+  options_map = defaultdict(lambda: copy(default_options))
+  subcommands_map = defaultdict(lambda: set())
+
+  for command in commands:
+    if len(command) == 1:
+
+      if _isOption(command[0]):
+        global_options.add(command[0])
+      else:
+        subcommands_map[name].add(command[0])
+
+    elif len(command) != 0:
+
+      subcommand = command[-2]
+      arg = _FormatForCommand(command[-1])
+
+      if _isOption(arg):
+        args_map = options_map
+      else:
+        args_map = subcommands_map
+
+      args_map[subcommand].add(arg)
+      args_map[subcommand.replace('_', '-')].add(arg)
+
+  return global_options, options_map, subcommands_map

--- a/fire/completion_test.py
+++ b/fire/completion_test.py
@@ -36,7 +36,10 @@ class TabCompletionTest(testutils.BaseTestCase):
     script = completion._BashScript(name='command', commands=commands)  # pylint: disable=protected-access
     self.assertIn('command', script)
     self.assertIn('halt', script)
-    self.assertIn('"$start" == "command"', script)
+
+    assert_template = "{command})"
+    for last_command in ['command', 'run', 'halt']:
+        self.assertIn(assert_template.format(command=last_command), script)
 
   def testCompletionFishScript(self):
     # A sanity check test to make sure the fish completion script satisfies

--- a/fire/completion_test.py
+++ b/fire/completion_test.py
@@ -38,7 +38,7 @@ class TabCompletionTest(testutils.BaseTestCase):
     self.assertIn('halt', script)
 
     assert_template = "{command})"
-    for last_command in ['command', 'run', 'halt']:
+    for last_command in ['command', 'halt']:
         self.assertIn(assert_template.format(command=last_command), script)
 
   def testCompletionFishScript(self):

--- a/fire/completion_test.py
+++ b/fire/completion_test.py
@@ -39,7 +39,7 @@ class TabCompletionTest(testutils.BaseTestCase):
 
     assert_template = "{command})"
     for last_command in ['command', 'halt']:
-        self.assertIn(assert_template.format(command=last_command), script)
+      self.assertIn(assert_template.format(command=last_command), script)
 
   def testCompletionFishScript(self):
     # A sanity check test to make sure the fish completion script satisfies


### PR DESCRIPTION
### Introduction

This PR changes the completion scripts that are generated by running the `--completion` option for the Fire generated commands. The changes are aimed to give more flexibility to the user. 

### Main Changes

- The highlight of this PR is the shift from using `start` based completion to `last-command` based completion. 
- In the `start` based completion, the entire string that has been entered into the command prompt so far is used to map the completion suggestions. This creates inflexibility for the user, causing #136.
- In the `last-command` based completion, suggestions are based on the last command/subcommand (non-option arg) entered by the user. This gives flexibility to the user, to be able to use options in any order, thereby fixing #136.

### Features

The features added are:

- Ability to use options in any order.
- Options that are already entered are not shown in the suggestion list.
- The completion script abides by the usage of Fire generated CLI commands, such that function arguments are removed from the suggestion list once a module level option _(or global option)_ is entered. In other words, module options come either before a function or after it's arguments _(see [guide](https://github.com/google/python-fire/blob/master/docs/guide.md#calling-functions))_
- All the above included for both: `bash` & `fish`