### PR TITLE
Check for self parameter

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -705,6 +705,8 @@ def _ParseArgs(fn_args, fn_defaults, num_required_args, kwargs,
   parsed_args = []
   for index, arg in enumerate(fn_args):
     value = kwargs.pop(arg, None)
+    if arg == 'self':
+      continue
     if value is not None:  # A value is specified at the command line.
       value = _ParseValue(value, index, arg, metadata)
       parsed_args.append(value)

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -683,6 +683,18 @@ class FireTest(testutils.BaseTestCase):
     with self.assertRaisesFireExit(2):
       fire.Fire(tc.InstanceVars, command=['--arg1=a1', '--arg2=a2', '-', 'jog'])
 
+  def testStrUpper(self):
+    # The property with no modification
+    self.assertEqual(
+        "myexcitingstring",
+        fire.Fire(tc.TypedProperties, command=['gamma'])
+    )
+    # The str.upper() call
+    self.assertEqual(
+        "MYEXCITINGSTRING",
+        fire.Fire(tc.TypedProperties, command=['gamma', 'upper'])
+    )
+
 
 if __name__ == '__main__':
   testutils.main()


### PR DESCRIPTION
Related to #150 , I also tried the example from `README.md`, and it failed to call the `str.upper()`. I tried the old tags, and none worked. So I guess one of the libraries (`oinspect`? `inspect`?), could have changed, and is now returning `self` in the list of arguments for the operation.

Tried with Python 2.7.15 (Ubuntu LTS), and Python 3.7 (Anaconda 5.3.1).

When that happens, the validation fails as the number of arguments provided (none), is different than the number of parameters required (1 at least, for `self`). I tried the most naive fix that I could think first, and it worked?

So added a few tests to confirm, executed the other tests, and it appears to be working? But definitely needs some better review.

Cheers
Bruno