### PR TITLE
Make namedtuple fields accessible by their name

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -419,7 +419,8 @@ def _Fire(component, args, context, name=None):
         # If the initial component is a class, keep an instance for use with -i.
         instance = component
 
-    elif isinstance(component, (list, tuple)) and remaining_args:
+    elif (isinstance(component, (list, tuple)) and remaining_args
+          and not inspectutils.isnamedtuple(component)):
       # The component is a tuple or list; we'll try to access a member.
       arg = remaining_args[0]
       try:
@@ -437,7 +438,8 @@ def _Fire(component, args, context, name=None):
       component_trace.AddAccessedProperty(
           component, index, [arg], filename, lineno)
 
-    elif isinstance(component, dict) and remaining_args:
+    elif ((isinstance(component, dict) or inspectutils.isnamedtuple(component))
+          and remaining_args):
       # The component is a dict; we'll try to access a member.
       target = remaining_args[0]
       if target in component:
@@ -449,6 +451,10 @@ def _Fire(component, args, context, name=None):
         # another type.
         # TODO(dbieber): Consider alternatives for accessing non-string keys.
         found_target = False
+        # If the component is a namedtuple, we need to convert it to dict to
+        # be able to use the .items() method.
+        if inspectutils.isnamedtuple(component):
+          component = component._asdict()
         for key, value in component.items():
           if target == str(key):
             component = value

--- a/fire/core.py
+++ b/fire/core.py
@@ -442,7 +442,23 @@ def _Fire(component, args, context, name=None):
           and remaining_args):
       # The component is a dict; we'll try to access a member.
       target = remaining_args[0]
-      if target in component:
+
+      # Allow indexing for namedtuples.
+      is_target_int = False
+      try:
+        index = int(target)
+        is_target_int = True
+      except: pass
+
+      if inspectutils.Isnamedtuple(component) and is_target_int:
+        try:
+          component = component[index]
+        except (ValueError, IndexError):
+          error = FireError(
+              'Unable to index into component with argument:', target)
+          component_trace.AddError(error, initial_args)
+          return component_trace
+      elif target in component:
         component = component[target]
       elif target.replace('-', '_') in component:
         component = component[target.replace('-', '_')]

--- a/fire/core.py
+++ b/fire/core.py
@@ -420,7 +420,7 @@ def _Fire(component, args, context, name=None):
         instance = component
 
     elif (isinstance(component, (list, tuple)) and remaining_args
-          and not inspectutils.isnamedtuple(component)):
+          and not inspectutils.Isnamedtuple(component)):
       # The component is a tuple or list; we'll try to access a member.
       arg = remaining_args[0]
       try:
@@ -438,7 +438,7 @@ def _Fire(component, args, context, name=None):
       component_trace.AddAccessedProperty(
           component, index, [arg], filename, lineno)
 
-    elif ((isinstance(component, dict) or inspectutils.isnamedtuple(component))
+    elif ((isinstance(component, dict) or inspectutils.Isnamedtuple(component))
           and remaining_args):
       # The component is a dict; we'll try to access a member.
       target = remaining_args[0]
@@ -453,7 +453,7 @@ def _Fire(component, args, context, name=None):
         found_target = False
         # If the component is a namedtuple, we need to convert it to dict to
         # be able to use the .items() method.
-        if inspectutils.isnamedtuple(component):
+        if inspectutils.Isnamedtuple(component):
           component = component._asdict()
         for key, value in component.items():
           if target == str(key):

--- a/fire/core.py
+++ b/fire/core.py
@@ -444,11 +444,11 @@ def _Fire(component, args, context, name=None):
       target = remaining_args[0]
 
       # Allow indexing for namedtuples.
-      is_target_int = False
       try:
         index = int(target)
         is_target_int = True
-      except: pass
+      except ValueError:
+        is_target_int = False
 
       if inspectutils.Isnamedtuple(component) and is_target_int:
         try:

--- a/fire/core.py
+++ b/fire/core.py
@@ -420,7 +420,7 @@ def _Fire(component, args, context, name=None):
         instance = component
 
     elif (isinstance(component, (list, tuple)) and remaining_args
-          and not inspectutils.Isnamedtuple(component)):
+          and not inspectutils.IsNamedTuple(component)):
       # The component is a tuple or list; we'll try to access a member.
       arg = remaining_args[0]
       try:
@@ -438,7 +438,7 @@ def _Fire(component, args, context, name=None):
       component_trace.AddAccessedProperty(
           component, index, [arg], filename, lineno)
 
-    elif ((isinstance(component, dict) or inspectutils.Isnamedtuple(component))
+    elif ((isinstance(component, dict) or inspectutils.IsNamedTuple(component))
           and remaining_args):
       # The component is a dict; we'll try to access a member.
       target = remaining_args[0]
@@ -450,7 +450,7 @@ def _Fire(component, args, context, name=None):
       except ValueError:
         is_target_int = False
 
-      if inspectutils.Isnamedtuple(component) and is_target_int:
+      if inspectutils.IsNamedTuple(component) and is_target_int:
         try:
           component = component[index]
         except (ValueError, IndexError):
@@ -469,7 +469,7 @@ def _Fire(component, args, context, name=None):
         found_target = False
         # If the component is a namedtuple, we need to convert it to dict to
         # be able to use the .items() method.
-        if inspectutils.Isnamedtuple(component):
+        if inspectutils.IsNamedTuple(component):
           component = component._asdict()
         for key, value in component.items():
           if target == str(key):

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -140,6 +140,10 @@ class CoreTest(testutils.BaseTestCase):
     with self.assertOutputMatches(stdout='{}'):
       core.Fire(tc.OrderedDictionary, command=['empty'])
 
+  def testPrintNamedTupleField(self):
+    with self.assertOutputMatches(stdout='11', stderr=None):
+      core.Fire(tc.NamedTuple, command=['point', 'x'])
+
   def testCallable(self):
     with self.assertOutputMatches(stdout=r'foo:\s+foo\s+', stderr=None):
       core.Fire(tc.CallableWithKeywordArgument(), command=['--foo=foo'])

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -144,6 +144,14 @@ class CoreTest(testutils.BaseTestCase):
     with self.assertOutputMatches(stdout='11', stderr=None):
       core.Fire(tc.NamedTuple, command=['point', 'x'])
 
+  def testPrintNamedTupleIndex(self):
+    with self.assertOutputMatches(stdout='22', stderr=None):
+      core.Fire(tc.NamedTuple, command=['point', '1'])
+
+  def testPrintNamedTupleNegativeIndex(self):
+    with self.assertOutputMatches(stdout='11', stderr=None):
+      core.Fire(tc.NamedTuple, command=['point', '-2'])
+
   def testCallable(self):
     with self.assertOutputMatches(stdout=r'foo:\s+foo\s+', stderr=None):
       core.Fire(tc.CallableWithKeywordArgument(), command=['--foo=foo'])

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -204,7 +204,7 @@ def _InfoBackup(component):
   return info
 
 
-def Isnamedtuple(component):
+def IsNamedTuple(component):
   """Return true if the component is a namedtuple.
 
   Unfortunately, Python offers no native way to check for a namedtuple type.

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -202,3 +202,25 @@ def _InfoBackup(component):
     pass
 
   return info
+
+
+def isnamedtuple(component):
+  """Return true if the component is a namedtuple.
+
+  Unfortunately, Python offers no native way to check for a namedtuple type.
+  Instead, we need to use a simple hack which should suffice for our case.
+  namedtuples are internally implemented as tuples, therefore we need to:
+    1. Check if the component is an instance of tuple.
+    2. Check if the component has a _fields attribute which regular tuples do
+       not have.
+
+  Args:
+    component: The component to analyze.
+  Returns:
+    True if the component is a namedtuple or False otherwise.
+  """
+  if not isinstance(component, tuple):
+      return False
+
+  has_fields = bool(getattr(component, '_fields', None))
+  return has_fields

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -204,7 +204,7 @@ def _InfoBackup(component):
   return info
 
 
-def isnamedtuple(component):
+def Isnamedtuple(component):
   """Return true if the component is a namedtuple.
 
   Unfortunately, Python offers no native way to check for a namedtuple type.
@@ -220,7 +220,7 @@ def isnamedtuple(component):
     True if the component is a namedtuple or False otherwise.
   """
   if not isinstance(component, tuple):
-      return False
+    return False
 
   has_fields = bool(getattr(component, '_fields', None))
   return has_fields

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -281,6 +281,7 @@ class NamedTuple(object):
 
   def point(self):
     """Point example straight from Python docs."""
+    # pylint: disable=invalid-name
     Point = collections.namedtuple('Point', ['x', 'y'])
     return Point(11, y=22)
 

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -277,6 +277,14 @@ class OrderedDictionary(object):
     return ordered_dict
 
 
+class NamedTuple(object):
+
+  def point(self):
+    """Point example straight from Python docs."""
+    Point = collections.namedtuple('Point', ['x', 'y'])
+    return Point(11, y=22)
+
+
 class CallableWithKeywordArgument(object):
   """Test class for supporting callable."""
 


### PR DESCRIPTION
Hi, this PR makes the fields of namedtuple objects accessible by their name instead of indices as requested in #157. Also, I extended the test suite and made sure that no existing tests broke.

The exact behaviour is explained in the following:

Assuming a `namedtuple_example.py` script:
```python
from collections import namedtuple
import fire

Point = namedtuple('Point', ['x', 'y'])
p = Point(11, y=22)

if __name__ == '__main__':
  fire.Fire(p)
```

Before the PR:
```
python namedtuple_example.py 0  # 11
python namedtuple_example.py 1  # 22
python namedtuple_example.py x  # Throws an exception.
```

After the PR:
```
python namedtuple_example.py x  # 11
python namedtuple_example.py y  # 22
python namedtuple_example.py 0  # Throws an exception since p has no '0' field.
```