### PR TITLE
Fix issue #164

### DIFF
--- a/fire/helputils_test.py
+++ b/fire/helputils_test.py
@@ -88,7 +88,6 @@ class HelpUtilsTest(testutils.BaseTestCase):
     helpstring = helputils.HelpString('test'.upper)
     self.assertIn('Type:        builtin_function_or_method', helpstring)
     self.assertIn('String form: <built-in method upper of', helpstring)
-    self.assertIn('Usage:       [VARS ...] [--KWARGS ...]', helpstring)
 
   def testHelpStringIntType(self):
     helpstring = helputils.HelpString(int)

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -74,10 +74,12 @@ def _GetArgSpecInfo(fn):
     if six.PY2 and hasattr(fn, '__init__'):
       fn = fn.__init__
   else:
-    # If the function is a bound method, we skip the `self` argument.
-    is_method = inspect.ismethod(fn)
-    skip_arg = is_method and fn.__self__ is not None
-
+    if inspect.ismethod(fn):
+      # If the function is a bound method, we skip the `self` argument.
+      skip_arg = fn.__self__ is not None
+    elif inspect.isbuiltin(fn):
+      # If the function is a bound builtin, we skip the `self` argument.
+      skip_arg = fn.__self__ is not None
   return fn, skip_arg
 
 

--- a/fire/inspectutils_test.py
+++ b/fire/inspectutils_test.py
@@ -56,8 +56,6 @@ class InspectUtilsTest(testutils.BaseTestCase):
     spec = inspectutils.GetFullArgSpec('test'.upper)
     self.assertEqual(spec.args, [])
     self.assertEqual(spec.defaults, ())
-    self.assertEqual(spec.varargs, 'vars')
-    self.assertEqual(spec.varkw, 'kwargs')
     self.assertEqual(spec.kwonlyargs, [])
     self.assertEqual(spec.kwonlydefaults, {})
     self.assertEqual(spec.annotations, {})


### PR DESCRIPTION
This PR is meant for fixing https://github.com/google/python-fire/issues/164

After careful analysis, I believe the problem is that `inspect.getargspec()` is showing different behavior. In particular, the function throws an error when a built-in is given in Python 3.6 but it doesn't in Python 3.7.

The `testHelpStringBuiltin` and `testGetFullArgSpecFromBuiltin` cases are explicitly verifying that we use this base case so that it has `vars` and `kwargs`.

The `testFireKeywordArgs` and `testFireObjectWithDict` cases are more subtle than that - the specific return value of `inspect.getargspec()` is `FullArgSpec(args=['self'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={})`, in particular, that `self` in `args` is causing the test cases to expect an extra parameter and leading to subsequent failures.

Once we move the `isbuiltin` test earlier, the behavioral difference are normalized and the test cases will all pass under both Python 3.6 and Python 3.7.

The official Python documentation does mention there is a change in 3.7, but enable inspection for built-in wasn't part of it. Search `getargspec` in the following page for more details.

https://docs.python.org/3/library/inspect.html