### PR TITLE
add console package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
 
     keywords='command line interface cli python fire interactive bash tool',
 
-    packages=['fire'],
+    packages=['fire', 'fire.console'],
 
     install_requires=DEPENDENCIES,
     tests_require=TEST_DEPENDENCIES,


### PR DESCRIPTION
It is a fix for:
```
>>> import fire
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/d_shushkevich/work/testvenv/lib/python3.7/site-packages/fire/__init__.py", line 21, in <module>
    from fire.core import Fire
  File "/Users/d_shushkevich/work/testvenv/lib/python3.7/site-packages/fire/core.py", line 73, in <module>
    from fire.console import console_pager
ModuleNotFoundError: No module named 'fire.console'
```