### PR TITLE
add pypi version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python Fire [![PyPI](https://img.shields.io/pypi/pyversions/fire.svg?style=plastic)](https://github.com/google/python-fire)
+# Python Fire [![PyPI](https://img.shields.io/pypi/pyversions/fire.svg?style=plastic)](https://github.com/google/python-fire) [![PyPI version](https://badge.fury.io/py/fire.svg)](https://badge.fury.io/py/fire)
 _Python Fire is a library for automatically generating command line interfaces
 (CLIs) from absolutely any Python object._
 


### PR DESCRIPTION
This useful badge helps developers know what the latest version number is directly.
Without this, we have to go to pypi.org to check the version number.