### PR TITLE
Exposes builtin functions from the standard library

### DIFF
--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import inspect
+import types
 from fire import docstrings
 
 import six
@@ -70,7 +71,7 @@ def _GetArgSpecInfo(fn):
   """
   skip_arg = False
   if inspect.isclass(fn):
-    # If the function is a class, we try to use it's init method.
+    # If the function is a class, we try to use its init method.
     skip_arg = True
     if six.PY2 and hasattr(fn, '__init__'):
       fn = fn.__init__
@@ -78,8 +79,11 @@ def _GetArgSpecInfo(fn):
     # If the function is a bound method, we skip the `self` argument.
     skip_arg = fn.__self__ is not None
   elif inspect.isbuiltin(fn):
-    # If the function is a bound builtin, we skip the `self` argument.
-    skip_arg = fn.__self__ is not None
+    # If the function is a bound builtin, we skip the `self` argument, unless
+    # the function is from a standard library module in which case its __self__
+    # attribute is that module.
+    if not isinstance(fn.__self__, types.ModuleType):
+        skip_arg = True
   elif not inspect.isfunction(fn):
     # The purpose of this else clause is to set skip_arg for callable objects.
     skip_arg = True

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -29,25 +29,25 @@ class FullArgSpec(object):
   """The arguments of a function, as in Python 3's inspect.FullArgSpec."""
 
   def __init__(self, args=None, varargs=None, varkw=None, defaults=None,
-               kwonlyargs=None, kwonlydefaults=None, annotations=None):
-    """Constructs a FullArgSpec with each provided attribute, or the default.
+         kwonlyargs=None, kwonlydefaults=None, annotations=None):
+  """Constructs a FullArgSpec with each provided attribute, or the default.
 
-    Args:
-      args: A list of the argument names accepted by the function.
-      varargs: The name of the *varargs argument or None if there isn't one.
-      varkw: The name of the **kwargs argument or None if there isn't one.
-      defaults: A tuple of the defaults for the arguments that accept defaults.
-      kwonlyargs: A list of argument names that must be passed with a keyword.
-      kwonlydefaults: A dictionary of keyword only arguments and their defaults.
-      annotations: A dictionary of arguments and their annotated types.
-    """
-    self.args = args or []
-    self.varargs = varargs
-    self.varkw = varkw
-    self.defaults = defaults or ()
-    self.kwonlyargs = kwonlyargs or []
-    self.kwonlydefaults = kwonlydefaults or {}
-    self.annotations = annotations or {}
+  Args:
+    args: A list of the argument names accepted by the function.
+    varargs: The name of the *varargs argument or None if there isn't one.
+    varkw: The name of the **kwargs argument or None if there isn't one.
+    defaults: A tuple of the defaults for the arguments that accept defaults.
+    kwonlyargs: A list of argument names that must be passed with a keyword.
+    kwonlydefaults: A dictionary of keyword only arguments and their defaults.
+    annotations: A dictionary of arguments and their annotated types.
+  """
+  self.args = args or []
+  self.varargs = varargs
+  self.varkw = varkw
+  self.defaults = defaults or ()
+  self.kwonlyargs = kwonlyargs or []
+  self.kwonlydefaults = kwonlydefaults or {}
+  self.annotations = annotations or {}
 
 
 def _GetArgSpecInfo(fn):
@@ -62,42 +62,42 @@ def _GetArgSpecInfo(fn):
   class with an __init__ method.
 
   Args:
-    fn: The function or class of interest.
+  fn: The function or class of interest.
   Returns:
-    A tuple with the following two items:
-      fn: The function to use for determining the arg spec of this function.
-      skip_arg: Whether the first argument will be supplied automatically, and
-        hence should be skipped when supplying args from a Fire command.
+  A tuple with the following two items:
+    fn: The function to use for determining the arg spec of this function.
+    skip_arg: Whether the first argument will be supplied automatically, and
+    hence should be skipped when supplying args from a Fire command.
   """
   skip_arg = False
   if inspect.isclass(fn):
-    # If the function is a class, we try to use its init method.
-    skip_arg = True
-    if six.PY2 and hasattr(fn, '__init__'):
-      fn = fn.__init__
+  # If the function is a class, we try to use its init method.
+  skip_arg = True
+  if six.PY2 and hasattr(fn, '__init__'):
+    fn = fn.__init__
   elif inspect.ismethod(fn):
-    # If the function is a bound method, we skip the `self` argument.
-    skip_arg = fn.__self__ is not None
+  # If the function is a bound method, we skip the `self` argument.
+  skip_arg = fn.__self__ is not None
   elif inspect.isbuiltin(fn):
-    # If the function is a bound builtin, we skip the `self` argument, unless
-    # the function is from a standard library module in which case its __self__
-    # attribute is that module.
-    if not isinstance(fn.__self__, types.ModuleType):
-        skip_arg = True
-  elif not inspect.isfunction(fn):
-    # The purpose of this else clause is to set skip_arg for callable objects.
+  # If the function is a bound builtin, we skip the `self` argument, unless
+  # the function is from a standard library module in which case its __self__
+  # attribute is that module.
+  if not isinstance(fn.__self__, types.ModuleType):
     skip_arg = True
+  elif not inspect.isfunction(fn):
+  # The purpose of this else clause is to set skip_arg for callable objects.
+  skip_arg = True
   return fn, skip_arg
 
 
 def Py2GetArgSpec(fn):
   """A wrapper around getargspec that tries both fn and fn.__call__."""
   try:
-    return inspect.getargspec(fn)  # pylint: disable=deprecated-method
+  return inspect.getargspec(fn)  # pylint: disable=deprecated-method
   except TypeError:
-    if hasattr(fn, '__call__'):
-      return inspect.getargspec(fn.__call__)  # pylint: disable=deprecated-method
-    raise
+  if hasattr(fn, '__call__'):
+    return inspect.getargspec(fn.__call__)  # pylint: disable=deprecated-method
+  raise
 
 
 def GetFullArgSpec(fn):
@@ -106,71 +106,71 @@ def GetFullArgSpec(fn):
   fn, skip_arg = _GetArgSpecInfo(fn)
 
   try:
-    if six.PY2:
-      args, varargs, varkw, defaults = Py2GetArgSpec(fn)
-      kwonlyargs = kwonlydefaults = None
-      annotations = getattr(fn, '__annotations__', None)
-    else:
-      (args, varargs, varkw, defaults,
-       kwonlyargs, kwonlydefaults, annotations) = inspect.getfullargspec(fn)  # pylint: disable=deprecated-method,no-member
+  if six.PY2:
+    args, varargs, varkw, defaults = Py2GetArgSpec(fn)
+    kwonlyargs = kwonlydefaults = None
+    annotations = getattr(fn, '__annotations__', None)
+  else:
+    (args, varargs, varkw, defaults,
+     kwonlyargs, kwonlydefaults, annotations) = inspect.getfullargspec(fn)  # pylint: disable=deprecated-method,no-member
 
   except TypeError:
-    # If we can't get the argspec, how do we know if the fn should take args?
-    # 1. If it's a builtin, it can take args.
-    # 2. If it's an implicit __init__ function (a 'slot wrapper'), that comes
-    # from a namedtuple, use _fields to determine the args.
-    # 3. If it's another slot wrapper (that comes from not subclassing object in
-    # Python 2), then there are no args.
-    # Are there other cases? We just don't know.
+  # If we can't get the argspec, how do we know if the fn should take args?
+  # 1. If it's a builtin, it can take args.
+  # 2. If it's an implicit __init__ function (a 'slot wrapper'), that comes
+  # from a namedtuple, use _fields to determine the args.
+  # 3. If it's another slot wrapper (that comes from not subclassing object in
+  # Python 2), then there are no args.
+  # Are there other cases? We just don't know.
 
-    # Case 1: Builtins accept args.
-    if inspect.isbuiltin(fn):
-      # TODO(dbieber): Try parsing the docstring, if available.
-      # TODO(dbieber): Use known argspecs, like set.add and namedtuple.count.
-      return FullArgSpec(varargs='vars', varkw='kwargs')
+  # Case 1: Builtins accept args.
+  if inspect.isbuiltin(fn):
+    # TODO(dbieber): Try parsing the docstring, if available.
+    # TODO(dbieber): Use known argspecs, like set.add and namedtuple.count.
+    return FullArgSpec(varargs='vars', varkw='kwargs')
 
-    # Case 2: namedtuples store their args in their _fields attribute.
-    # TODO(dbieber): Determine if there's a way to detect false positives.
-    # In Python 2, a class that does not subclass anything, does not define
-    # __init__, and has an attribute named _fields will cause Fire to think it
-    # expects args for its constructor when in fact it does not.
-    fields = getattr(original_fn, '_fields', None)
-    if fields is not None:
-      return FullArgSpec(args=list(fields))
+  # Case 2: namedtuples store their args in their _fields attribute.
+  # TODO(dbieber): Determine if there's a way to detect false positives.
+  # In Python 2, a class that does not subclass anything, does not define
+  # __init__, and has an attribute named _fields will cause Fire to think it
+  # expects args for its constructor when in fact it does not.
+  fields = getattr(original_fn, '_fields', None)
+  if fields is not None:
+    return FullArgSpec(args=list(fields))
 
-    # Case 3: Other known slot wrappers do not accept args.
-    return FullArgSpec()
+  # Case 3: Other known slot wrappers do not accept args.
+  return FullArgSpec()
 
   if skip_arg and args:
-    args.pop(0)  # Remove 'self' or 'cls' from the list of arguments.
+  args.pop(0)  # Remove 'self' or 'cls' from the list of arguments.
 
   return FullArgSpec(args, varargs, varkw, defaults,
-                     kwonlyargs, kwonlydefaults, annotations)
+           kwonlyargs, kwonlydefaults, annotations)
 
 
 def GetFileAndLine(component):
   """Returns the filename and line number of component.
 
   Args:
-    component: A component to find the source information for, usually a class
-        or routine.
+  component: A component to find the source information for, usually a class
+    or routine.
   Returns:
-    filename: The name of the file where component is defined.
-    lineno: The line number where component is defined.
+  filename: The name of the file where component is defined.
+  lineno: The line number where component is defined.
   """
   if inspect.isbuiltin(component):
-    return None, None
+  return None, None
 
   try:
-    filename = inspect.getsourcefile(component)
+  filename = inspect.getsourcefile(component)
   except TypeError:
-    return None, None
+  return None, None
 
   try:
-    unused_code, lineindex = inspect.findsource(component)
-    lineno = lineindex + 1
+  unused_code, lineindex = inspect.findsource(component)
+  lineno = lineindex + 1
   except IOError:
-    lineno = None
+  lineno = None
 
   return filename, lineno
 
@@ -179,40 +179,40 @@ def Info(component):
   """Returns a dict with information about the given component.
 
   The dict will have at least some of the following fields.
-    type_name: The type of `component`.
-    string_form: A string representation of `component`.
-    file: The file in which `component` is defined.
-    line: The line number at which `component` is defined.
-    docstring: The docstring of `component`.
-    init_docstring: The init docstring of `component`.
-    class_docstring: The class docstring of `component`.
-    call_docstring: The call docstring of `component`.
-    length: The length of `component`.
+  type_name: The type of `component`.
+  string_form: A string representation of `component`.
+  file: The file in which `component` is defined.
+  line: The line number at which `component` is defined.
+  docstring: The docstring of `component`.
+  init_docstring: The init docstring of `component`.
+  class_docstring: The class docstring of `component`.
+  call_docstring: The call docstring of `component`.
+  length: The length of `component`.
 
   Args:
-    component: The component to analyze.
+  component: The component to analyze.
   Returns:
-    A dict with information about the component.
+  A dict with information about the component.
   """
   try:
-    from IPython.core import oinspect  # pylint: disable=g-import-not-at-top
-    inspector = oinspect.Inspector()
-    info = inspector.info(component)
+  from IPython.core import oinspect  # pylint: disable=g-import-not-at-top
+  inspector = oinspect.Inspector()
+  info = inspector.info(component)
 
-    # IPython's oinspect.Inspector.info may return '<no docstring>'
-    if info['docstring'] == '<no docstring>':
-      info['docstring'] = None
+  # IPython's oinspect.Inspector.info may return '<no docstring>'
+  if info['docstring'] == '<no docstring>':
+    info['docstring'] = None
   except ImportError:
-    info = _InfoBackup(component)
+  info = _InfoBackup(component)
 
   try:
-    unused_code, lineindex = inspect.findsource(component)
-    info['line'] = lineindex + 1
+  unused_code, lineindex = inspect.findsource(component)
+  info['line'] = lineindex + 1
   except (TypeError, IOError):
-    info['line'] = None
+  info['line'] = None
 
   if 'docstring' in info:
-    info['docstring_info'] = docstrings.parse(info['docstring'])
+  info['docstring_info'] = docstrings.parse(info['docstring'])
 
   return info
 
@@ -226,9 +226,9 @@ def _InfoBackup(component):
   by oinspect.
 
   Args:
-    component: The component to analyze.
+  component: The component to analyze.
   Returns:
-    A dict with information about the component.
+  A dict with information about the component.
   """
   info = {}
 
@@ -241,9 +241,9 @@ def _InfoBackup(component):
   info['docstring'] = inspect.getdoc(component)
 
   try:
-    info['length'] = str(len(component))
+  info['length'] = str(len(component))
   except (TypeError, AttributeError):
-    pass
+  pass
 
   return info
 
@@ -254,17 +254,17 @@ def IsNamedTuple(component):
   Unfortunately, Python offers no native way to check for a namedtuple type.
   Instead, we need to use a simple hack which should suffice for our case.
   namedtuples are internally implemented as tuples, therefore we need to:
-    1. Check if the component is an instance of tuple.
-    2. Check if the component has a _fields attribute which regular tuples do
-       not have.
+  1. Check if the component is an instance of tuple.
+  2. Check if the component has a _fields attribute which regular tuples do
+     not have.
 
   Args:
-    component: The component to analyze.
+  component: The component to analyze.
   Returns:
-    True if the component is a namedtuple or False otherwise.
+  True if the component is a namedtuple or False otherwise.
   """
   if not isinstance(component, tuple):
-    return False
+  return False
 
   has_fields = bool(getattr(component, '_fields', None))
   return has_fields

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -29,25 +29,25 @@ class FullArgSpec(object):
   """The arguments of a function, as in Python 3's inspect.FullArgSpec."""
 
   def __init__(self, args=None, varargs=None, varkw=None, defaults=None,
-         kwonlyargs=None, kwonlydefaults=None, annotations=None):
-  """Constructs a FullArgSpec with each provided attribute, or the default.
+               kwonlyargs=None, kwonlydefaults=None, annotations=None):
+    """Constructs a FullArgSpec with each provided attribute, or the default.
 
-  Args:
-    args: A list of the argument names accepted by the function.
-    varargs: The name of the *varargs argument or None if there isn't one.
-    varkw: The name of the **kwargs argument or None if there isn't one.
-    defaults: A tuple of the defaults for the arguments that accept defaults.
-    kwonlyargs: A list of argument names that must be passed with a keyword.
-    kwonlydefaults: A dictionary of keyword only arguments and their defaults.
-    annotations: A dictionary of arguments and their annotated types.
-  """
-  self.args = args or []
-  self.varargs = varargs
-  self.varkw = varkw
-  self.defaults = defaults or ()
-  self.kwonlyargs = kwonlyargs or []
-  self.kwonlydefaults = kwonlydefaults or {}
-  self.annotations = annotations or {}
+    Args:
+      args: A list of the argument names accepted by the function.
+      varargs: The name of the *varargs argument or None if there isn't one.
+      varkw: The name of the **kwargs argument or None if there isn't one.
+      defaults: A tuple of the defaults for the arguments that accept defaults.
+      kwonlyargs: A list of argument names that must be passed with a keyword.
+      kwonlydefaults: A dictionary of keyword only arguments and their defaults.
+      annotations: A dictionary of arguments and their annotated types.
+    """
+    self.args = args or []
+    self.varargs = varargs
+    self.varkw = varkw
+    self.defaults = defaults or ()
+    self.kwonlyargs = kwonlyargs or []
+    self.kwonlydefaults = kwonlydefaults or {}
+    self.annotations = annotations or {}
 
 
 def _GetArgSpecInfo(fn):
@@ -62,42 +62,42 @@ def _GetArgSpecInfo(fn):
   class with an __init__ method.
 
   Args:
-  fn: The function or class of interest.
+    fn: The function or class of interest.
   Returns:
-  A tuple with the following two items:
-    fn: The function to use for determining the arg spec of this function.
-    skip_arg: Whether the first argument will be supplied automatically, and
-    hence should be skipped when supplying args from a Fire command.
+    A tuple with the following two items:
+      fn: The function to use for determining the arg spec of this function.
+      skip_arg: Whether the first argument will be supplied automatically, and
+        hence should be skipped when supplying args from a Fire command.
   """
   skip_arg = False
   if inspect.isclass(fn):
-  # If the function is a class, we try to use its init method.
-  skip_arg = True
-  if six.PY2 and hasattr(fn, '__init__'):
-    fn = fn.__init__
-  elif inspect.ismethod(fn):
-  # If the function is a bound method, we skip the `self` argument.
-  skip_arg = fn.__self__ is not None
-  elif inspect.isbuiltin(fn):
-  # If the function is a bound builtin, we skip the `self` argument, unless
-  # the function is from a standard library module in which case its __self__
-  # attribute is that module.
-  if not isinstance(fn.__self__, types.ModuleType):
+    # If the function is a class, we try to use its init method.
     skip_arg = True
+    if six.PY2 and hasattr(fn, '__init__'):
+      fn = fn.__init__
+  elif inspect.ismethod(fn):
+    # If the function is a bound method, we skip the `self` argument.
+    skip_arg = fn.__self__ is not None
+  elif inspect.isbuiltin(fn):
+    # If the function is a bound builtin, we skip the `self` argument, unless
+    # the function is from a standard library module in which case its __self__
+    # attribute is that module.
+    if not isinstance(fn.__self__, types.ModuleType):
+      skip_arg = True
   elif not inspect.isfunction(fn):
-  # The purpose of this else clause is to set skip_arg for callable objects.
-  skip_arg = True
+    # The purpose of this else clause is to set skip_arg for callable objects.
+    skip_arg = True
   return fn, skip_arg
 
 
 def Py2GetArgSpec(fn):
   """A wrapper around getargspec that tries both fn and fn.__call__."""
   try:
-  return inspect.getargspec(fn)  # pylint: disable=deprecated-method
+    return inspect.getargspec(fn)  # pylint: disable=deprecated-method
   except TypeError:
-  if hasattr(fn, '__call__'):
-    return inspect.getargspec(fn.__call__)  # pylint: disable=deprecated-method
-  raise
+    if hasattr(fn, '__call__'):
+      return inspect.getargspec(fn.__call__)  # pylint: disable=deprecated-method
+    raise
 
 
 def GetFullArgSpec(fn):
@@ -106,71 +106,71 @@ def GetFullArgSpec(fn):
   fn, skip_arg = _GetArgSpecInfo(fn)
 
   try:
-  if six.PY2:
-    args, varargs, varkw, defaults = Py2GetArgSpec(fn)
-    kwonlyargs = kwonlydefaults = None
-    annotations = getattr(fn, '__annotations__', None)
-  else:
-    (args, varargs, varkw, defaults,
-     kwonlyargs, kwonlydefaults, annotations) = inspect.getfullargspec(fn)  # pylint: disable=deprecated-method,no-member
+    if six.PY2:
+      args, varargs, varkw, defaults = Py2GetArgSpec(fn)
+      kwonlyargs = kwonlydefaults = None
+      annotations = getattr(fn, '__annotations__', None)
+    else:
+      (args, varargs, varkw, defaults,
+       kwonlyargs, kwonlydefaults, annotations) = inspect.getfullargspec(fn)  # pylint: disable=deprecated-method,no-member
 
   except TypeError:
-  # If we can't get the argspec, how do we know if the fn should take args?
-  # 1. If it's a builtin, it can take args.
-  # 2. If it's an implicit __init__ function (a 'slot wrapper'), that comes
-  # from a namedtuple, use _fields to determine the args.
-  # 3. If it's another slot wrapper (that comes from not subclassing object in
-  # Python 2), then there are no args.
-  # Are there other cases? We just don't know.
+    # If we can't get the argspec, how do we know if the fn should take args?
+    # 1. If it's a builtin, it can take args.
+    # 2. If it's an implicit __init__ function (a 'slot wrapper'), that comes
+    # from a namedtuple, use _fields to determine the args.
+    # 3. If it's another slot wrapper (that comes from not subclassing object in
+    # Python 2), then there are no args.
+    # Are there other cases? We just don't know.
 
-  # Case 1: Builtins accept args.
-  if inspect.isbuiltin(fn):
-    # TODO(dbieber): Try parsing the docstring, if available.
-    # TODO(dbieber): Use known argspecs, like set.add and namedtuple.count.
-    return FullArgSpec(varargs='vars', varkw='kwargs')
+    # Case 1: Builtins accept args.
+    if inspect.isbuiltin(fn):
+      # TODO(dbieber): Try parsing the docstring, if available.
+      # TODO(dbieber): Use known argspecs, like set.add and namedtuple.count.
+      return FullArgSpec(varargs='vars', varkw='kwargs')
 
-  # Case 2: namedtuples store their args in their _fields attribute.
-  # TODO(dbieber): Determine if there's a way to detect false positives.
-  # In Python 2, a class that does not subclass anything, does not define
-  # __init__, and has an attribute named _fields will cause Fire to think it
-  # expects args for its constructor when in fact it does not.
-  fields = getattr(original_fn, '_fields', None)
-  if fields is not None:
-    return FullArgSpec(args=list(fields))
+    # Case 2: namedtuples store their args in their _fields attribute.
+    # TODO(dbieber): Determine if there's a way to detect false positives.
+    # In Python 2, a class that does not subclass anything, does not define
+    # __init__, and has an attribute named _fields will cause Fire to think it
+    # expects args for its constructor when in fact it does not.
+    fields = getattr(original_fn, '_fields', None)
+    if fields is not None:
+      return FullArgSpec(args=list(fields))
 
-  # Case 3: Other known slot wrappers do not accept args.
-  return FullArgSpec()
+    # Case 3: Other known slot wrappers do not accept args.
+    return FullArgSpec()
 
   if skip_arg and args:
-  args.pop(0)  # Remove 'self' or 'cls' from the list of arguments.
+    args.pop(0)  # Remove 'self' or 'cls' from the list of arguments.
 
   return FullArgSpec(args, varargs, varkw, defaults,
-           kwonlyargs, kwonlydefaults, annotations)
+                     kwonlyargs, kwonlydefaults, annotations)
 
 
 def GetFileAndLine(component):
   """Returns the filename and line number of component.
 
   Args:
-  component: A component to find the source information for, usually a class
-    or routine.
+    component: A component to find the source information for, usually a class
+        or routine.
   Returns:
-  filename: The name of the file where component is defined.
-  lineno: The line number where component is defined.
+    filename: The name of the file where component is defined.
+    lineno: The line number where component is defined.
   """
   if inspect.isbuiltin(component):
-  return None, None
+    return None, None
 
   try:
-  filename = inspect.getsourcefile(component)
+    filename = inspect.getsourcefile(component)
   except TypeError:
-  return None, None
+    return None, None
 
   try:
-  unused_code, lineindex = inspect.findsource(component)
-  lineno = lineindex + 1
+    unused_code, lineindex = inspect.findsource(component)
+    lineno = lineindex + 1
   except IOError:
-  lineno = None
+    lineno = None
 
   return filename, lineno
 
@@ -179,40 +179,40 @@ def Info(component):
   """Returns a dict with information about the given component.
 
   The dict will have at least some of the following fields.
-  type_name: The type of `component`.
-  string_form: A string representation of `component`.
-  file: The file in which `component` is defined.
-  line: The line number at which `component` is defined.
-  docstring: The docstring of `component`.
-  init_docstring: The init docstring of `component`.
-  class_docstring: The class docstring of `component`.
-  call_docstring: The call docstring of `component`.
-  length: The length of `component`.
+    type_name: The type of `component`.
+    string_form: A string representation of `component`.
+    file: The file in which `component` is defined.
+    line: The line number at which `component` is defined.
+    docstring: The docstring of `component`.
+    init_docstring: The init docstring of `component`.
+    class_docstring: The class docstring of `component`.
+    call_docstring: The call docstring of `component`.
+    length: The length of `component`.
 
   Args:
-  component: The component to analyze.
+    component: The component to analyze.
   Returns:
-  A dict with information about the component.
+    A dict with information about the component.
   """
   try:
-  from IPython.core import oinspect  # pylint: disable=g-import-not-at-top
-  inspector = oinspect.Inspector()
-  info = inspector.info(component)
+    from IPython.core import oinspect  # pylint: disable=g-import-not-at-top
+    inspector = oinspect.Inspector()
+    info = inspector.info(component)
 
-  # IPython's oinspect.Inspector.info may return '<no docstring>'
-  if info['docstring'] == '<no docstring>':
-    info['docstring'] = None
+    # IPython's oinspect.Inspector.info may return '<no docstring>'
+    if info['docstring'] == '<no docstring>':
+      info['docstring'] = None
   except ImportError:
-  info = _InfoBackup(component)
+    info = _InfoBackup(component)
 
   try:
-  unused_code, lineindex = inspect.findsource(component)
-  info['line'] = lineindex + 1
+    unused_code, lineindex = inspect.findsource(component)
+    info['line'] = lineindex + 1
   except (TypeError, IOError):
-  info['line'] = None
+    info['line'] = None
 
   if 'docstring' in info:
-  info['docstring_info'] = docstrings.parse(info['docstring'])
+    info['docstring_info'] = docstrings.parse(info['docstring'])
 
   return info
 
@@ -226,9 +226,9 @@ def _InfoBackup(component):
   by oinspect.
 
   Args:
-  component: The component to analyze.
+    component: The component to analyze.
   Returns:
-  A dict with information about the component.
+    A dict with information about the component.
   """
   info = {}
 
@@ -241,9 +241,9 @@ def _InfoBackup(component):
   info['docstring'] = inspect.getdoc(component)
 
   try:
-  info['length'] = str(len(component))
+    info['length'] = str(len(component))
   except (TypeError, AttributeError):
-  pass
+    pass
 
   return info
 
@@ -254,17 +254,17 @@ def IsNamedTuple(component):
   Unfortunately, Python offers no native way to check for a namedtuple type.
   Instead, we need to use a simple hack which should suffice for our case.
   namedtuples are internally implemented as tuples, therefore we need to:
-  1. Check if the component is an instance of tuple.
-  2. Check if the component has a _fields attribute which regular tuples do
-     not have.
+    1. Check if the component is an instance of tuple.
+    2. Check if the component has a _fields attribute which regular tuples do
+       not have.
 
   Args:
-  component: The component to analyze.
+    component: The component to analyze.
   Returns:
-  True if the component is a namedtuple or False otherwise.
+    True if the component is a namedtuple or False otherwise.
   """
   if not isinstance(component, tuple):
-  return False
+    return False
 
   has_fields = bool(getattr(component, '_fields', None))
   return has_fields


### PR DESCRIPTION
This PR exposes builtin functions from the standard library to fire and fixes #187.

Previously, certain builtin functions from the standard library (e.g. `math.sin`) would raise a TypeError complaining about getting one less required argument than they need. The original diagnosis was that these functions were written in C and did not expose their signature to`inspect.getfullargspec` or `inspect.signature`. However `math.sin` does expose its signature to these inspect functions:

```python
>>> inspect.getfullargspec(math.sin)
FullArgSpec(args=['x'], varargs=None, varkw=None, defaults=None, kwonlyargs=
[], kwonlydefaults=None, annotations={})
```

The problem was that `fire.inspectutils._GetArgSpecInfo` was incorrectly skipping the first argument of these builtins under the assumption that a non-null `__self__` attribute of a builtin always means that the function is a method and its first argument is `self`. However, for builtin functions in standard libraries, the `__self__` attribute is the module it came from. The proposed fix is to only skip the first argument of builtins if the `__self__` attribute isn't a module.

