### PR TITLE
use a custom getfullargspec that follows wrapped chains #159

### DIFF
--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -193,10 +193,12 @@ class CoreTest(testutils.BaseTestCase):
     )
 
   def testLruCacheDecoratorBoundArg(self):
-    self.assertEqual(core.Fire(tc.LruCacheDecoratedMethod, command=['lru_cache_in_class', 'foo']), 'foo')
+    self.assertEqual(core.Fire(tc.LruCacheDecoratedMethod,
+                               command=['lru_cache_in_class', 'foo']), 'foo')
 
   def testLruCacheDecorator(self):
     self.assertEqual(core.Fire(tc.lru_cache_decorated, command=['foo']), 'foo')
+
 
 if __name__ == '__main__':
   testutils.main()

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -192,5 +192,11 @@ class CoreTest(testutils.BaseTestCase):
         7,
     )
 
+  def testLruCacheDecoratorBoundArg(self):
+    self.assertEqual(core.Fire(tc.LruCacheDecoratedMethod, command=['lru_cache_in_class', 'foo']), 'foo')
+
+  def testLruCacheDecorator(self):
+    self.assertEqual(core.Fire(tc.lru_cache_decorated, command=['foo']), 'foo')
+
 if __name__ == '__main__':
   testutils.main()

--- a/fire/decorators_test.py
+++ b/fire/decorators_test.py
@@ -22,8 +22,6 @@ from fire import core
 from fire import decorators
 from fire import testutils
 
-import six
-
 
 class NoDefaults(object):
   """A class for testing decorated functions without default values."""
@@ -90,25 +88,6 @@ class WithVarArgs(object):
   @decorators.SetParseFn(str)
   def example7(self, arg1, arg2=None, *varargs, **kwargs):  # pylint: disable=keyword-arg-before-vararg
     return arg1, arg2, varargs, kwargs
-
-
-if six.PY2:
-  def lru_cache():
-    def wrapper(func):
-      return func
-    return wrapper
-else:
-  from functools import lru_cache
-
-
-class LruCacheDecorator(object):
-  @lru_cache()
-  def example8(self, arg1):
-    return arg1
-
-@lru_cache()
-def lru_cache_decorated(arg1):
-    return arg1
 
 
 class FireDecoratorsTest(testutils.BaseTestCase):
@@ -190,11 +169,6 @@ class FireDecoratorsTest(testutils.BaseTestCase):
                   command=['example7', '1', '--arg2=2', '3', '4', '--kwarg=5']),
         ('1', '2', ('3', '4'), {'kwarg': '5'}))
 
-  def testLruCacheDecoratorBoundArg(self):
-    self.assertEqual(core.Fire(LruCacheDecorator, command=['example8', 'foo']), 'foo')
-
-  def testLruCacheDecorator(self):
-      self.assertEqual(core.Fire(lru_cache_decorated, command=['foo']), 'foo')
 
 if __name__ == '__main__':
   testutils.main()

--- a/fire/decorators_test.py
+++ b/fire/decorators_test.py
@@ -22,6 +22,8 @@ from fire import core
 from fire import decorators
 from fire import testutils
 
+import six
+
 
 class NoDefaults(object):
   """A class for testing decorated functions without default values."""
@@ -88,6 +90,25 @@ class WithVarArgs(object):
   @decorators.SetParseFn(str)
   def example7(self, arg1, arg2=None, *varargs, **kwargs):  # pylint: disable=keyword-arg-before-vararg
     return arg1, arg2, varargs, kwargs
+
+
+if six.PY2:
+  def lru_cache():
+    def wrapper(func):
+      return func
+    return wrapper
+else:
+  from functools import lru_cache
+
+
+class LruCacheDecorator(object):
+  @lru_cache()
+  def example8(self, arg1):
+    return arg1
+
+@lru_cache()
+def lru_cache_decorated(arg1):
+    return arg1
 
 
 class FireDecoratorsTest(testutils.BaseTestCase):
@@ -169,6 +190,11 @@ class FireDecoratorsTest(testutils.BaseTestCase):
                   command=['example7', '1', '--arg2=2', '3', '4', '--kwarg=5']),
         ('1', '2', ('3', '4'), {'kwarg': '5'}))
 
+  def testLruCacheDecoratorBoundArg(self):
+    self.assertEqual(core.Fire(LruCacheDecorator, command=['example8', 'foo']), 'foo')
+
+  def testLruCacheDecorator(self):
+      self.assertEqual(core.Fire(lru_cache_decorated, command=['foo']), 'foo')
 
 if __name__ == '__main__':
   testutils.main()

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -703,6 +703,7 @@ class FireTest(testutils.BaseTestCase):
     with self.assertRaisesFireExit(2):
       fire.Fire(tc.InstanceVars, command=['--arg1=a1', '--arg2=a2', '-', 'jog'])
 
+  @unittest.skipIf(six.PY2, 'Inspecting wrapper chain signature not implemented on Python 2.')
   def testHelpKwargsDecorator(self):
     # Issue #190, follow the wrapped method instead of crashing
     with self.assertRaisesFireExit(0):

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -703,13 +703,14 @@ class FireTest(testutils.BaseTestCase):
     with self.assertRaisesFireExit(2):
       fire.Fire(tc.InstanceVars, command=['--arg1=a1', '--arg2=a2', '-', 'jog'])
 
-  @unittest.skipIf(six.PY2, 'Inspecting wrapper chain signature not implemented on Python 2.')
+  @unittest.skipIf(six.PY2, 'Cannot inspect wrapped signatures in Python 2.')
   def testHelpKwargsDecorator(self):
     # Issue #190, follow the wrapped method instead of crashing
     with self.assertRaisesFireExit(0):
       fire.Fire(tc.decorated_method, command=['-h'])
     with self.assertRaisesFireExit(0):
       fire.Fire(tc.decorated_method, command=['--help'])
+
 
 if __name__ == '__main__':
   testutils.main()

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -703,6 +703,12 @@ class FireTest(testutils.BaseTestCase):
     with self.assertRaisesFireExit(2):
       fire.Fire(tc.InstanceVars, command=['--arg1=a1', '--arg2=a2', '-', 'jog'])
 
+  def testHelpKwargsDecorator(self):
+    # Issue #190, follow the wrapped method instead of crashing
+    with self.assertRaisesFireExit(0):
+      fire.Fire(tc.decorated_method, command=['-h'])
+    with self.assertRaisesFireExit(0):
+      fire.Fire(tc.decorated_method, command=['--help'])
 
 if __name__ == '__main__':
   testutils.main()

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -100,8 +100,6 @@ def Py2GetArgSpec(fn):
     raise
 
 
-
-
 def custom_getfullargspec(func):
   """Taken from CPython inspect.getfullargspec:
     The method is deprecated and uses

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -100,23 +100,31 @@ def Py2GetArgSpec(fn):
     raise
 
 
-def custom_getfullargspec(func):
-  """Taken from CPython inspect.getfullargspec:
-    The method is deprecated and uses
+def GetFullArgSpecPy3(func):
+  """ Get the name and default values of 'func' parameters
 
-    skip_bound_args=False
-    and follow_wrapped_chains=False
-    because it was legacy behavior
+  Taken from CPython inspect.getfullargspec:
+  The method is deprecated and uses
 
-    We need the opposite to follow the wrapped methods, and skip the bound arguments
-    instead of manually removing them
+  skip_bound_args=False
+  and follow_wrapped_chains=False
+  because it was legacy behavior
+
+  We need the opposite to follow the wrapped methods,
+  and skip the bound arguments instead of manually removing them
+
+  Args:
+    fn: The function or class of interest.
+  Returns:
+    a named tuple: FullArgSpec(args, varargs, varkw, defaults,
+      kwonlyargs, kwonlydefaults, annotations)
   """
 
   try:
     sig = inspect._signature_from_callable(func,
-                                   skip_bound_arg=True,
-                                   follow_wrapper_chains=True,
-                                   sigcls=inspect.Signature)
+                                           skip_bound_arg=True,
+                                           follow_wrapper_chains=True,
+                                           sigcls=inspect.Signature)
   except Exception as ex:
     # Most of the times 'signature' will raise ValueError.
     # But, it can also raise AttributeError, and, maybe something
@@ -180,7 +188,7 @@ def GetFullArgSpec(fn):
       annotations = getattr(fn, '__annotations__', None)
     else:
       (args, varargs, varkw, defaults,
-       kwonlyargs, kwonlydefaults, annotations) = custom_getfullargspec(fn)
+       kwonlyargs, kwonlydefaults, annotations) = GetFullArgSpecPy3(fn)
 
   except TypeError:
     # If we can't get the argspec, how do we know if the fn should take args?

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -500,6 +500,7 @@ class BinaryCanvas(object):
     self.pixels[self._row][self._col] = value
     return self
 
+
 # LRU cache decorator to reproduce issue #145
 if six.PY2:
   def lru_cache():

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -500,6 +500,26 @@ class BinaryCanvas(object):
     self.pixels[self._row][self._col] = value
     return self
 
+# LRU cache decorator to reproduce issue #145
+if six.PY2:
+  def lru_cache():
+    def wrapper(func):
+      return func
+    return wrapper
+else:
+  from functools import lru_cache
+
+
+class LruCacheDecoratedMethod(object):
+  @lru_cache()
+  def lru_cache_in_class(self, arg1):
+    return arg1
+
+
+@lru_cache()
+def lru_cache_decorated(arg1):
+  return arg1
+
 
 def simple_decorator(f):
   @functools.wraps(f)

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -19,6 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import functools
 
 import enum
 import six
@@ -498,3 +499,15 @@ class BinaryCanvas(object):
   def set(self, value):
     self.pixels[self._row][self._col] = value
     return self
+
+
+def simple_decorator(f):
+  @functools.wraps(f)
+  def wrapper(*args, **kwargs):
+    return f(*args, **kwargs)
+  return wrapper
+
+
+@simple_decorator
+def decorated_method(name='World'):
+  return 'Hello %s' % name


### PR DESCRIPTION
using complex decorators like @functools.lru_cache()
was breaking positional parameters handling

We used `inspect.getfullargspec()`, that ignores `__wrapped__` attributes for legacy reasons
It is based internally on `inspect.signature()` which allows following the chain of
`__wrapped__` attributes

I took the code from getfullargspec() and changed it to use
skip_bound_arg=True and follow_wrapper_chains=True

This fixes the lru_cache decorator usage and allows to remove
a line that was getting rid of the bound args.

This applies only to Python3, Python2 wasn't affected by this issue