### PR TITLE
Use "dir()" to get available methods of object

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -632,7 +632,7 @@ def _GetMember(component, args):
   Raises:
     FireError: If we cannot consume an argument to get a member.
   """
-  members = dict(inspect.getmembers(component))
+  members = dir(component)
   arg = args[0]
   arg_names = [
       arg,
@@ -641,7 +641,7 @@ def _GetMember(component, args):
 
   for arg_name in arg_names:
     if arg_name in members:
-      return members[arg_name], [arg], args[1:]
+      return getattr(component, arg_name), [arg], args[1:]
 
   raise FireError('Could not consume arg:', arg)
 

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -703,6 +703,11 @@ class FireTest(testutils.BaseTestCase):
     with self.assertRaisesFireExit(2):
       fire.Fire(tc.InstanceVars, command=['--arg1=a1', '--arg2=a2', '-', 'jog'])
 
+  def testClassWithDefaultMethod(self):
+    self.assertEqual(
+        fire.Fire(tc.DefaultMethod, command=['double', '10']), 20
+    )
+
 
 if __name__ == '__main__':
   testutils.main()

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -505,6 +505,6 @@ class DefaultMethod(object):
     return 2 * number
 
   def __getattr__(self, name):
-    def _missing(*args, **kwargs):
+    def _missing():
       return "Undefined Function"
     return _missing

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -498,3 +498,13 @@ class BinaryCanvas(object):
   def set(self, value):
     self.pixels[self._row][self._col] = value
     return self
+
+class DefaultMethod(object):
+
+  def double(self, number):
+    return 2 * number
+
+  def __getattr__(self, name):
+    def _missing(*args, **kwargs):
+      return "Undefined Function"
+    return _missing


### PR DESCRIPTION
* Fix #149 
* Use `dir()` instead of `inspect.getmembers()` to get available methods of given object.
* Refer #149 for explanation.