### PR TITLE
Support printing classes with overridden str method as SimpleGroups #197

### DIFF
--- a/fire/completion.py
+++ b/fire/completion.py
@@ -318,7 +318,10 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
     return False
   if verbose:
     return True
-  if isinstance(member, type(absolute_import)):
+  # Python 3.7.6 evaluates type(absolute_import) == __future__._Feature while
+  # Python 2.7.16 (Base macOS Catalina) evaluates
+  # type(absolute_import) == <type 'instance'>
+  if isinstance(member, type(absolute_import)) and six.PY34:
     return False
   if inspect.ismodule(member) and member is six:
     # TODO(dbieber): Determine more generally which modules to hide.

--- a/fire/value_types.py
+++ b/fire/value_types.py
@@ -37,7 +37,8 @@ def IsCommand(component):
 
 
 def IsValue(component):
-  return isinstance(component, VALUE_TYPES)
+  return isinstance(component, VALUE_TYPES) or (
+      hasattr(component, '__str__') and inspect.ismethod(component.__str__))
 
 
 def IsSimpleGroup(component):


### PR DESCRIPTION
Fixes #197 

Tested with the following classes:
```python
class Value(object):
    """Original question"""
    def __init__(self, name):
        self.name = name
    def __repr__(self):
        return "%s(name=%r)" % (self.__class__.__name__, self.name)


class NewValue:
    """As expressed in comments"""
    def __init__(self, name):
        self.name = name
    def __repr__(self):
        return "%s(name=%r)" % (self.__class__.__name__, self.name)
    def __str__(self):
        return repr(self)
```

### Python 2.7
```bash
% python --version
Python 2.7.16
% python -c "import sys; sys.path.append('../python-fire'); import fire; fire.Fire({'key1': 'value1', 'key2': 'value2'})"
key2: value2
key1: value1
```

### Python 3.7
```bash
% python3.7 --version                                                                                                     
Python 3.7.6
% python3.7 -c "import sys; sys.path.append('../python-fire'); import fire; fire.Fire({'key1': 'value1', 'key2': 'value2'})"
key1: value1
key2: value2
```

### Python 3.8
```bash
% python3.8 --version
Python 3.8.1
% python3.8 -c "import sys; sys.path.append('../python-fire'); import fire; fire.Fire({'key1': 'value1', 'key2': 'value2'})"
key1: value1
key2: value2
```