### PR TITLE
Enable ANSI support on Windows #186

### DIFF
--- a/fire/formatting.py
+++ b/fire/formatting.py
@@ -33,7 +33,7 @@ if sys.platform.startswith('win'):
     HAS_COLORAMA = False
 
   if HAS_COLORAMA:
-    SHOULD_WRAP = True
+    SHOULD_WRAP = False
     if sys.stdout.isatty() and sys.getwindowsversion().major == 10: # pylint: disable=no-member
       """Enables native ANSI sequences in console. Windows 10,
       2016, and 2019 only."""
@@ -46,14 +46,14 @@ if sys.platform.startswith('win'):
       # GetConsoleMode fails if the terminal isn't native.
       MODE = ctypes.wintypes.DWORD()
       if KERNEL32.GetConsoleMode(OUT_HANDLE, ctypes.byref(MODE)) == 0:
-        SHOULD_WRAP = False
+        SHOULD_WRAP = True
       if not (MODE.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING):
         if KERNEL32.SetConsoleMode(
             OUT_HANDLE, MODE.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING) == 0:
           print(
               'kernel32.SetConsoleMode to enable ANSI sequences failed',
               file=sys.stderr)
-          SHOULD_WRAP = False
+          SHOULD_WRAP = True
     colorama.init(wrap=SHOULD_WRAP)
   else:
     os.environ['ANSI_COLORS_DISABLED'] = "1"

--- a/fire/formatting.py
+++ b/fire/formatting.py
@@ -36,11 +36,11 @@ if sys.platform.startswith('win'):
   if HAS_COLORAMA:
     SHOULD_WRAP = True
     if sys.stdout.isatty() and platform.release() == '10':
-      """Enables native ANSI sequences in console. Windows 10,
-      2016, and 2019 only."""
+      # Enables native ANSI sequences in console. Windows 10,
+      # 2016, and 2019 only.
       import ctypes
       import subprocess
-      
+
       SHOULD_WRAP = False
       KERNEL32 = ctypes.windll.kernel32
       ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x04
@@ -49,7 +49,7 @@ if sys.platform.startswith('win'):
       MODE = ctypes.wintypes.DWORD()
       if KERNEL32.GetConsoleMode(OUT_HANDLE, ctypes.byref(MODE)) == 0:
         SHOULD_WRAP = True
-      if not (MODE.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING):
+      if not MODE.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING:
         if KERNEL32.SetConsoleMode(
             OUT_HANDLE, MODE.value | ENABLE_VIRTUAL_TERMINAL_PROCESSING) == 0:
           print(

--- a/fire/formatting.py
+++ b/fire/formatting.py
@@ -33,13 +33,14 @@ if sys.platform.startswith('win'):
     HAS_COLORAMA = False
 
   if HAS_COLORAMA:
-    SHOULD_WRAP = False
+    SHOULD_WRAP = True
     if sys.stdout.isatty() and sys.getwindowsversion().major == 10: # pylint: disable=no-member
       """Enables native ANSI sequences in console. Windows 10,
       2016, and 2019 only."""
       import ctypes
       import subprocess
-
+      
+      SHOULD_WRAP = False
       KERNEL32 = ctypes.windll.kernel32
       ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x04
       OUT_HANDLE = KERNEL32.GetStdHandle(subprocess.STD_OUTPUT_HANDLE)

--- a/fire/formatting.py
+++ b/fire/formatting.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import sys
 import os
+import platform
 import termcolor
 
 ELLIPSIS = '...'
@@ -34,7 +35,7 @@ if sys.platform.startswith('win'):
 
   if HAS_COLORAMA:
     SHOULD_WRAP = True
-    if sys.stdout.isatty() and sys.getwindowsversion().major == 10: # pylint: disable=no-member
+    if sys.stdout.isatty() and platform.release() == '10':
       """Enables native ANSI sequences in console. Windows 10,
       2016, and 2019 only."""
       import ctypes


### PR DESCRIPTION
This commit enables support for correct ANSI output on Windows when the colorama library is installed. If the colorama library is not installed then ANSI characters in output are disabled with the `ANSI_COLORS_DISABLED` environment variable.

Additionally, native ANSI sequences are enabled on the Windows 10 platform when support is detected.

Tested on the following platforms:
* Windows Server 2012R2
* Windows 10
* Windows Server 2016
* Windows Server 2019

With the following consoles:
* conhost.exe (cmd.exe)
* powershell.exe
* openconsole.exe [Windows Terminal](https://github.com/microsoft/terminal)

Fixes #186 