### PR TITLE
Support 3.8 with tests fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
   - pip install --upgrade pylint pytest pytest-pylint pytest-runner
 
 install:
-  - pip install termcolor
-  - pip install hypothesis python-Levenshtein
+  - pip install termcolor hypothesis python-Levenshtein
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.4 ]]; then pip install pytype; fi
   - python setup.py develop
 
 script:
@@ -20,15 +20,12 @@ script:
   - pip install ipython
   - python -m pytest  # Now run the tests with IPython.
   - pylint fire --ignore=test_components_py3.py,parser_fuzz_test.py,console
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.4 ]]; then
-      pip install pytype;
-    fi
   # Run type-checking, excluding files that define or use py3 features in py2.
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
       pytype -x
         fire/fire_test.py
         fire/inspectutils_test.py
         fire/test_components_py3.py;
-    elif [[ $TRAVIS_PYTHON_VERSION != 3.4 ]]; then
-      pytype;
     fi
+  # Waiting for Python 3.8 support: https://github.com/google/pytype/pull/587
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.* && $TRAVIS_PYTHON_VERSION != 3.[48] ]]; then pytype; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,17 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
-  - "3.6"
-# Workaround for testing Python 3.7:
-# https://github.com/travis-ci/travis-ci/issues/9815
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: yes
+  - "3.7"
+
 before_install:
   - pip install --upgrade setuptools pip
   - pip install --upgrade pylint pytest pytest-pylint pytest-runner
+
 install:
   - pip install termcolor
   - pip install hypothesis python-Levenshtein
   - python setup.py develop
+
 script:
   - python -m pytest  # Run the tests without IPython.
   - pip install ipython

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.7"
+  - "3.8"
 
 before_install:
   - pip install --upgrade setuptools pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ script:
         fire/test_components_py3.py;
     fi
   # Waiting for Python 3.8 support: https://github.com/google/pytype/pull/587
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.* && $TRAVIS_PYTHON_VERSION != 3.[48] ]]; then pytype; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.* && $TRAVIS_PYTHON_VERSION != 3.4 ]]; then pytype; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,4 @@ script:
         fire/inspectutils_test.py
         fire/test_components_py3.py;
     fi
-  # Waiting for Python 3.8 support: https://github.com/google/pytype/pull/587
   - if [[ $TRAVIS_PYTHON_VERSION == 3.* && $TRAVIS_PYTHON_VERSION != 3.4 ]]; then pytype; fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python Fire [![PyPI](https://img.shields.io/pypi/pyversions/fire.svg?style=plastic)](https://github.com/google/python-fire)
+# Python Fire [![PyPI](https://img.shields.io/pypi/pyversions/fire.svg?style=plastic)](https://github.com/google/python-fire) [![Build Status](https://travis-ci.org/google/python-fire.svg?branch=master)](https://travis-ci.org/google/python-fire)
 
 _Python Fire is a library for automatically generating command line interfaces
 (CLIs) from absolutely any Python object._

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -326,7 +326,7 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
         # not uninstantiated classes.
         return False
       tuplegetter = getattr(collections, '_tuplegetter', None)
-      if tuplegetter and isinstance(class_attr.object, type(tuplegetter)):
+      if tuplegetter is not None and isinstance(class_attr.object, tuplegetter):
         # backward compatibility: namedtuple attributes were properties
         return False
   if (six.PY2 and inspect.isfunction(component)

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -325,7 +325,7 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
         # methods and properties should be accessed on instantiated objects,
         # not uninstantiated classes.
         return False
-      tuplegetter = getattr(collections, '_tuplegetter', None)
+      tuplegetter = getattr(collections, '_tuplegetter', type(None))
       if tuplegetter is not None and isinstance(class_attr.object, tuplegetter):
         # backward compatibility: namedtuple attributes were properties
         return False

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import collections
 import copy
 import inspect
-import sys
 
 from fire import inspectutils
 import six
@@ -326,8 +325,9 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
         # methods and properties should be accessed on instantiated objects,
         # not uninstantiated classes.
         return False
-      if sys.version_info >= (3, 8) and isinstance(class_attr.object, collections._tuplegetter):
-        # backward compatibility: namedtuple elements was properties
+      tuplegetter = getattr(collections, '_tuplegetter', None)
+      if tuplegetter and isinstance(class_attr.object, type(tuplegetter)):
+        # backward compatibility: namedtuple attributes were properties
         return False
   if (six.PY2 and inspect.isfunction(component)
       and name in ('func_closure', 'func_code', 'func_defaults',

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import collections
 import copy
 import inspect
+import sys
 
 from fire import inspectutils
 import six
@@ -320,10 +321,14 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
     if class_attrs is None:
       class_attrs = inspectutils.GetClassAttrsDict(class_attrs) or {}
     class_attr = class_attrs.get(name)
-    if class_attr and class_attr.kind in ('method', 'property'):
-      # methods and properties should be accessed on instantiated objects,
-      # not uninstantiated classes.
-      return False
+    if class_attr:
+      if class_attr.kind in ('method', 'property'):
+        # methods and properties should be accessed on instantiated objects,
+        # not uninstantiated classes.
+        return False
+      if sys.version_info >= (3, 8) and isinstance(class_attr.object, collections._tuplegetter):
+        # backward compatibility: namedtuple elements was properties
+        return False
   if (six.PY2 and inspect.isfunction(component)
       and name in ('func_closure', 'func_code', 'func_defaults',
                    'func_dict', 'func_doc', 'func_globals', 'func_name')):

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -326,7 +326,7 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
         # not uninstantiated classes.
         return False
       tuplegetter = getattr(collections, '_tuplegetter', type(None))
-      if tuplegetter is not None and isinstance(class_attr.object, tuplegetter):
+      if isinstance(class_attr.object, tuplegetter):
         # backward compatibility: namedtuple attributes were properties
         return False
   if (six.PY2 and inspect.isfunction(component)

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
 
         'Operating System :: OS Independent',
         'Operating System :: POSIX',

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
 
         'Operating System :: OS Independent',
         'Operating System :: POSIX',


### PR DESCRIPTION
Hi!

I want to use Fire in project with Python 3.8, so I think library should be officially supported for 3.8.

I added travis run for 3.8 and one test `testInitRequiresFlagSyntaxSubclassNamedTuple` got failed: [link](https://travis-ci.org/github/uburuntu/python-fire/jobs/691255265).

Investigation showed that now namedtuple attributes of type `collections._tuplegetter` since 3.8, not `property`: [link](https://github.com/python/cpython/blame/3.8/Lib/collections/__init__.py#L454), [commit](https://github.com/python/cpython/commit/3f5fc70c6213008243e7d605f7d8a2d8f94cf919):
- ![](https://i.imgur.com/3xLPnNx.jpg)
- ![](https://i.imgur.com/umlQkrj.jpg)

So I added backward compatibility check in `MemberVisible` function.

One not solved trouble: pytype does not support 3.8 (https://github.com/google/pytype/pull/587) -- https://travis-ci.org/github/uburuntu/python-fire, but I can add check in `travis.yml` to skip it currently.