### PR TITLE
Update: unittest extension for python 3.x

### DIFF
--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -22,7 +22,11 @@ from fire import core
 from fire import test_components as tc
 from fire import testutils
 from fire import trace
-import mock
+
+try:
+  import mock  # python 2.x
+except ModuleNotFoundError:
+  from unittest import mock  # python 3.x
 
 import six
 

--- a/fire/fire_import_test.py
+++ b/fire/fire_import_test.py
@@ -18,7 +18,10 @@ import sys
 
 import fire
 from fire import testutils
-import mock
+try:
+  import mock  # python 2.x
+except ModuleNotFoundError:
+  from unittest import mock  # python 3.x
 
 
 class FireImportTest(testutils.BaseTestCase):

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -25,7 +25,10 @@ import fire
 from fire import test_components as tc
 from fire import testutils
 
-import mock
+try:
+  import mock  # python 2.x
+except ModuleNotFoundError:
+  from unittest import mock  # python 3.x
 import six
 
 

--- a/fire/interact_test.py
+++ b/fire/interact_test.py
@@ -21,7 +21,10 @@ from __future__ import print_function
 from fire import interact
 from fire import testutils
 
-import mock
+try:
+  import mock  # python 2.x
+except ModuleNotFoundError:
+  from unittest import mock  # python 3.x
 
 
 try:

--- a/fire/testutils.py
+++ b/fire/testutils.py
@@ -26,7 +26,10 @@ import unittest
 from fire import core
 from fire import trace
 
-import mock
+try:
+  import mock  # python 2.x
+except ModuleNotFoundError:
+  from unittest import mock  # python 3.x
 import six
 
 


### PR DESCRIPTION
Hi,
  The mock object library has been integrated into the unittest module in python3.x, so I try to add extention like this.

`try:`

    import mock  # python 2.x

`except ModuleNotFoundError:`

    from unittest import mock  # python 3.x

Thanks for watching.