### PR TITLE
Changed completion argparse to allow control of the depth variable.

### DIFF
--- a/fire/completion.py
+++ b/fire/completion.py
@@ -26,10 +26,10 @@ from fire import inspectutils
 import six
 
 
-def Script(name, component, default_options=None, shell='bash'):
+def Script(name, component, shell='bash', depth=3, default_options=None):
   if shell == 'fish':
-    return _FishScript(name, _Commands(component), default_options)
-  return _BashScript(name, _Commands(component), default_options)
+    return _FishScript(name, _Commands(component, int(depth)), default_options)
+  return _BashScript(name, _Commands(component, int(depth)), default_options)
 
 
 def _BashScript(name, commands, default_options=None):

--- a/fire/core.py
+++ b/fire/core.py
@@ -171,9 +171,9 @@ def Display(lines, out):
   console_io.More(text, out=out)
 
 
-def CompletionScript(name, component, shell):
+def CompletionScript(name, component, *args):
   """Returns the text of the completion script for a Fire CLI."""
-  return completion.Script(name, component, shell=shell)
+  return completion.Script(name, component, *args)
 
 
 class FireError(Exception):
@@ -591,7 +591,7 @@ def _Fire(component, args, parsed_flag_args, context, name=None):
   if show_completion is not None:
     if name is None:
       raise ValueError('Cannot make completion script without command name')
-    script = CompletionScript(name, initial_component, shell=show_completion)
+    script = CompletionScript(name, initial_component, *show_completion)
     component_trace.AddCompletionScript(script)
 
   if interactive:

--- a/fire/parser.py
+++ b/fire/parser.py
@@ -27,7 +27,7 @@ def CreateParser():
   parser.add_argument('--verbose', '-v', action='store_true')
   parser.add_argument('--interactive', '-i', action='store_true')
   parser.add_argument('--separator', default='-')
-  parser.add_argument('--completion', nargs='?', const='bash', type=str)
+  parser.add_argument('--completion', nargs='*')
   parser.add_argument('--help', '-h', action='store_true')
   parser.add_argument('--trace', '-t', action='store_true')
   # TODO(dbieber): Consider allowing name to be passed as an argument.


### PR DESCRIPTION
Now you can run
`widget -- --completion fish 5`
to change the depth of completion.

Signed-off-by: Tomer Ben Gera <bengeratomer@gmail.com>