### PR TITLE
Issue 259: Add :key: parameters to help string

### DIFF
--- a/fire/docstrings.py
+++ b/fire/docstrings.py
@@ -290,7 +290,7 @@ def _get_or_create_arg_by_name(state, name, is_kwarg=False):
   Returns:
     The new Arg.
   """
-  for arg in state.args:
+  for arg in state.args + state.kwargs:
     if arg.name == name:
       return arg
   arg = Namespace()  # TODO(dbieber): Switch to an explicit class.

--- a/fire/docstrings_test.py
+++ b/fire/docstrings_test.py
@@ -24,6 +24,7 @@ from fire import testutils
 
 DocstringInfo = docstrings.DocstringInfo  # pylint: disable=invalid-name
 ArgInfo = docstrings.ArgInfo  # pylint: disable=invalid-name
+KwargInfo = docstrings.KwargInfo  # pylint: disable=invalid-name
 
 
 class DocstringsTest(testutils.BaseTestCase):
@@ -276,6 +277,30 @@ class DocstringsTest(testutils.BaseTestCase):
                     description='arg2, default:None'),
             ArgInfo(name='arg3', type='bool', description=None),
         ]
+    )
+    self.assertEqual(expected_docstring_info, docstring_info)
+
+  def test_rst_format_typed_args_and_kwargs(self):
+    docstring = """Docstring summary.
+
+    :param arg1: Description of arg1.
+    :type arg1: str.
+    :key arg2: Description of arg2.
+    :type arg2: bool.
+    :key arg3: Description of arg3.
+    :type arg3: str.
+    """
+    docstring_info = docstrings.parse(docstring)
+    expected_docstring_info = DocstringInfo(
+        summary='Docstring summary.',
+        args=[
+            ArgInfo(name='arg1', type='str',
+                    description='Description of arg1.'),
+            KwargInfo(name='arg2', type='bool',
+                      description='Description of arg2.'),
+            KwargInfo(name='arg3', type='str',
+                      description='Description of arg3.'),
+        ],
     )
     self.assertEqual(expected_docstring_info, docstring_info)
 

--- a/fire/helptext.py
+++ b/fire/helptext.py
@@ -220,9 +220,10 @@ def _ArgsAndFlagsSections(info, spec, metadata):
   flag_items = positional_flag_items + kwonly_flag_items
 
   if spec.varkw:
+    flag_string = '--{flag_name}'
     documented_kwargs = [
         _CreateFlagItem(flag.name, docstring_info, spec,
-                        flag_string=f"--{flag.name}")
+                        flag_string=flag_string.format(flag_name=flag.name))
         for flag in docstring_info.args
         if isinstance(flag, KwargInfo)
     ]

--- a/fire/helptext.py
+++ b/fire/helptext.py
@@ -220,20 +220,21 @@ def _ArgsAndFlagsSections(info, spec, metadata):
   flag_items = positional_flag_items + kwonly_flag_items
 
   if spec.varkw:
-    flag_string = '--{flag_name}'
+    # Include kwargs documented via :key param:
+    flag_string = '--{name}'
     documented_kwargs = [
         _CreateFlagItem(flag.name, docstring_info, spec,
-                        flag_string=flag_string.format(flag_name=flag.name))
-        for flag in docstring_info.args
+                        flag_string=flag_string.format(name=flag.name))
+        for flag in docstring_info.args or []
         if isinstance(flag, KwargInfo)
     ]
     if documented_kwargs:
-      message = 'The following flags are also accepted.'
-      item = _CreateItem(message, None, indent=4)
-      flag_items.append('')
-      flag_items.append(item)
+      # Separate documented kwargs from other flags using a message
+      if flag_items:
+        message = 'The following flags are also accepted.'
+        item = _CreateItem(message, None, indent=4)
+        flag_items.append(item)
       flag_items.extend(documented_kwargs)
-      flag_items.append('')
 
     description = _GetArgDescription(spec.varkw, docstring_info)
     if documented_kwargs:

--- a/fire/helptext_test.py
+++ b/fire/helptext_test.py
@@ -99,6 +99,34 @@ class HelpTest(testutils.BaseTestCase):
         help_screen)
     self.assertNotIn('NOTES', help_screen)
 
+  def testHelpTextFunctionWithKwargs(self):
+    component = tc.fn_with_kwarg
+    help_screen = helptext.HelpText(
+        component=component,
+        trace=trace.FireTrace(component, name='text'))
+    self.assertIn('NAME\n    text', help_screen)
+    self.assertIn('SYNOPSIS\n    text ARG1 ARG2 <flags>', help_screen)
+    self.assertIn('DESCRIPTION\n    Function with kwarg', help_screen)
+    self.assertIn(
+        'FLAGS\n    --arg3\n        Description of arg3.\n    '
+        'Additional undocumented flags may also be accepted.',
+        help_screen)
+
+  def testHelpTextFunctionWithKwargsAndDefaults(self):
+    component = tc.fn_with_kwarg_and_defaults
+    help_screen = helptext.HelpText(
+        component=component,
+        trace=trace.FireTrace(component, name='text'))
+    self.assertIn('NAME\n    text', help_screen)
+    self.assertIn('SYNOPSIS\n    text ARG1 ARG2 <flags>', help_screen)
+    self.assertIn('DESCRIPTION\n    Function with kwarg', help_screen)
+    self.assertIn(
+        'FLAGS\n    --opt=OPT\n        Default: True\n'
+        '    The following flags are also accepted.'
+        '\n    --arg3\n        Description of arg3.\n    '
+        'Additional undocumented flags may also be accepted.',
+        help_screen)
+
   @testutils.skipIf(
       sys.version_info[0:2] < (3, 5),
       'Python < 3.5 does not support type hints.')

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -539,3 +539,25 @@ def simple_decorator(f):
 @simple_decorator
 def decorated_method(name='World'):
   return 'Hello %s' % name
+
+
+def fn_with_kwarg(arg1, arg2, **kwargs):
+  """Function with kwarg
+
+  :param arg1: Description of arg1.
+  :param arg2: Description of arg2.
+  :key arg3: Description of arg3.
+  """
+  del arg1, arg2
+  return kwargs.get('arg3')
+
+
+def fn_with_kwarg_and_defaults(arg1, arg2, opt=True, **kwargs):
+  """Function with kwarg and defaults
+
+  :param arg1: Description of arg1.
+  :param arg2: Description of arg2.
+  :key arg3: Description of arg3.
+  """
+  del arg1, arg2, opt
+  return kwargs.get('arg3')


### PR DESCRIPTION
Resolves #259 

Add `:key:` parameters under flags as so
```
FLAGS
    --arg=ARG
    The following flags are also accepted.
    --key
        Description of the `key` kwarg from the docstring
    Additional undocumented flags may also be accepted.
```