### PR TITLE
Fix enum34 requirement in setup.py for python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ A library for automatically generating command line interfaces.""".strip()
 DEPENDENCIES = [
     'six',
     'termcolor',
-] + (['enum34'] if sys.version < '3.4' else [])
+    'enum34; python_version < "3.4"'
+]
 
 TEST_DEPENDENCIES = [
     'hypothesis',


### PR DESCRIPTION
The preferred way to specify a requirement that depends on python version is to do something like `'<packagename>; python_version < "3.4"'`, not to do the sys.version check as is currently being done.

I am running into an issue where a wheel is built with py2 and the cached wheel metadata is used again when installing the package for python 3.7, thus incorrectly including `enum34`. 

This same issue is addressed in the stack overflow responses [here](https://stackoverflow.com/a/21082173/6112221) 