### PR TITLE
Fix #315 Change the _KeywordOnlyArguments filtering condition

### DIFF
--- a/fire/helptext.py
+++ b/fire/helptext.py
@@ -700,7 +700,7 @@ def _GetCallableUsageItems(spec, metadata):
 
 def _KeywordOnlyArguments(spec, required=True):
   return (flag for flag in spec.kwonlyargs
-          if required == (flag in spec.kwonlydefaults))
+          if required != (flag in spec.kwonlydefaults))
 
 
 def _GetCallableAvailabilityLines(spec):

--- a/fire/helptext_test.py
+++ b/fire/helptext_test.py
@@ -497,6 +497,20 @@ class UsageTest(testutils.BaseTestCase):
         textwrap.dedent(expected_output).lstrip('\n'),
         usage_output)
 
+  def testUsageOutputFunctionMixedDefaults(self):
+    component = tc.MixedDefaults().identity2
+    t = trace.FireTrace(component, name='FunctionMixedDefaults')
+    usage_output = helptext.UsageText(component, trace=t, verbose=False)
+    expected_output = """
+    Usage: FunctionMixedDefaults <flags>
+      optional flags:        --beta
+      required flags:        --alpha
+
+    For detailed information on this command, run:
+      FunctionMixedDefaults --help"""
+    expected_output = textwrap.dedent(expected_output).lstrip('\n')
+    self.assertEqual(expected_output, usage_output)
+
   def testUsageOutputCallable(self):
     # This is both a group and a command.
     component = tc.CallableWithKeywordArgument()

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -133,6 +133,9 @@ class MixedDefaults(object):
   def identity(self, alpha, beta='0'):
     return alpha, beta
 
+  def identity2(self, *, alpha, beta='0'):
+    return alpha, beta
+
 
 class SimilarArgNames(object):
 


### PR DESCRIPTION
Fix #315 by changing the _KeywordOnlyArguments filtering condition.

The condition checked for the presence of the flag in the `kwonlydefaults` field of `FullArgSpec` to consider it as required, but that actually proved the opossite.