### PR TITLE
Fix #309 Missing helptext for multiline argument

### DIFF
--- a/fire/docstrings.py
+++ b/fire/docstrings.py
@@ -338,7 +338,8 @@ def _as_arg_name_and_type(text):
   tokens = text.split()
   if len(tokens) < 2:
     return None
-  if _is_arg_name(tokens[0]):
+  if _is_arg_name(tokens[0]) and not _is_arg_name(tokens[1]):
+  # if _is_arg_name(tokens[0]):
     type_token = ' '.join(tokens[1:])
     type_token = type_token.lstrip('{([').rstrip('])}')
     return tokens[0], type_token
@@ -406,7 +407,8 @@ def _consume_google_args_line(line_info, state):
         state.current_arg = arg
       else:
         if state.current_arg:
-          state.current_arg.description.lines.append(split_line[0])
+          state.current_arg.description.lines.append(first + ':' + second)
+          # state.current_arg.description.lines.append(split_line[0])
   else:
     if state.current_arg:
       state.current_arg.description.lines.append(split_line[0])

--- a/fire/docstrings.py
+++ b/fire/docstrings.py
@@ -392,18 +392,16 @@ def _consume_google_args_line(line_info, state):
   split_line = line_info.remaining.split(':', 1)
   if len(split_line) > 1:
     first, second = split_line  # first is either the "arg" or "arg (type)"
-    new_line = line_info.indentation <= line_info.previous.indentation
+    new_arg = line_info.indentation <= line_info.previous.indentation
     if _is_arg_name(first.strip()) and (
-      state.current_arg is None or new_line
-    ):
+        state.current_arg is None or new_arg):
       arg = _get_or_create_arg_by_name(state, first.strip())
       arg.description.lines.append(second.strip())
       state.current_arg = arg
     else:
       arg_name_and_type = _as_arg_name_and_type(first)
       if arg_name_and_type and (
-        state.current_arg is None or new_line
-      ):
+          state.current_arg is None or new_arg):
         arg_name, type_str = arg_name_and_type
         arg = _get_or_create_arg_by_name(state, arg_name)
         arg.type.lines.append(type_str)

--- a/fire/docstrings_test.py
+++ b/fire/docstrings_test.py
@@ -170,7 +170,7 @@ class DocstringsTest(testutils.BaseTestCase):
     )
     self.assertEqual(expected_docstring_info, docstring_info)
 
-  def test_google_format_multiline_arg_description_with_colon(self):
+  def test_google_format_multiline_arg_description_colon(self):
     docstring = """Docstring summary.
 
     This is a longer description of the docstring. It spans multiple lines, as
@@ -193,6 +193,60 @@ class DocstringsTest(testutils.BaseTestCase):
                     description='The second parameter. This has a lot of text, '
                                 'enough to cover two lines. This description '
                                 'also contains a : colon.'),
+        ],
+    )
+    self.assertEqual(expected_docstring_info, docstring_info)
+
+  def test_google_format_multiline_arg_description_colon_wrapped(self):
+    docstring = """Docstring summary.
+
+    This is a longer description of the docstring. It spans multiple lines, as
+    is allowed.
+
+    Args:
+        param1 (int): The first parameter.
+        param2 (str): The second parameter. This description contains a
+          colon : after the first word of the wrapped line.
+    """
+    docstring_info = docstrings.parse(docstring)
+    expected_docstring_info = DocstringInfo(
+        summary='Docstring summary.',
+        description='This is a longer description of the docstring. It spans '
+        'multiple lines, as\nis allowed.',
+        args=[
+            ArgInfo(name='param1', type='int',
+                    description='The first parameter.'),
+            ArgInfo(name='param2', type='str',
+                    description='The second parameter. This description '
+                                'contains a colon : after the first word '
+                                'of the wrapped line.'),
+        ],
+    )
+    self.assertEqual(expected_docstring_info, docstring_info)
+
+  def test_google_format_multiline_arg_description_colon_parenthesis(self):
+    docstring = """Docstring summary.
+
+    This is a longer description of the docstring. It spans multiple lines, as
+    is allowed.
+
+    Args:
+        param1 (int): The first parameter.
+        param2 (str): The second parameter. This description contains a
+          colon (and): parenthesis after the first word of the wrapped line.
+    """
+    docstring_info = docstrings.parse(docstring)
+    expected_docstring_info = DocstringInfo(
+        summary='Docstring summary.',
+        description='This is a longer description of the docstring. It spans '
+        'multiple lines, as\nis allowed.',
+        args=[
+            ArgInfo(name='param1', type='int',
+                    description='The first parameter.'),
+            ArgInfo(name='param2', type='str',
+                    description='The second parameter. This description '
+                                'contains a colon (and): parenthesis after '
+                                'the first word of the wrapped line.'),
         ],
     )
     self.assertEqual(expected_docstring_info, docstring_info)

--- a/fire/docstrings_test.py
+++ b/fire/docstrings_test.py
@@ -170,6 +170,33 @@ class DocstringsTest(testutils.BaseTestCase):
     )
     self.assertEqual(expected_docstring_info, docstring_info)
 
+  def test_google_format_multiline_arg_description_with_colon(self):
+    docstring = """Docstring summary.
+
+    This is a longer description of the docstring. It spans multiple lines, as
+    is allowed.
+
+    Args:
+        param1 (int): The first parameter.
+        param2 (str): The second parameter. This has a lot of text, enough to
+        cover two lines. This description also contains a : colon.
+    """
+    docstring_info = docstrings.parse(docstring)
+    expected_docstring_info = DocstringInfo(
+        summary='Docstring summary.',
+        description='This is a longer description of the docstring. It spans '
+        'multiple lines, as\nis allowed.',
+        args=[
+            ArgInfo(name='param1', type='int',
+                    description='The first parameter.'),
+            ArgInfo(name='param2', type='str',
+                    description='The second parameter. This has a lot of text, '
+                                'enough to cover two lines. This description '
+                                'also contains a : colon.'),
+        ],
+    )
+    self.assertEqual(expected_docstring_info, docstring_info)
+
   def test_rst_format_typed_args_and_returns(self):
     docstring = """Docstring summary.
 


### PR DESCRIPTION
Closes #309 

Having colons on wrapped lines no longer causes missing help-text for multiline arguments, as long as the user follows the Google Python Style Guide for docstring args: use a hanging indent of 2 or 4 spaces more than the parameter name.

@MichaelCG8 can you review this? Thanks :)