### PR TITLE
Add custom formatter for Fire result

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -249,7 +249,9 @@ def _PrintResult(component_trace, verbose=False, serialize=None):
 
   # Allow users to modify the return value of the component and provide 
   # custom formatting.
-  if callable(serialize):
+  if serialize:
+    if not callable(serialize):
+      raise FireError("serialize must be callable.")
     result = serialize(result)
 
   if value_types.HasCustomStr(result):

--- a/fire/core.py
+++ b/fire/core.py
@@ -78,7 +78,7 @@ if six.PY34:
   import asyncio  # pylint: disable=import-error,g-import-not-at-top  # pytype: disable=import-error
 
 
-def Fire(component=None, command=None, name=None, formatter=None):
+def Fire(component=None, command=None, name=None, serialize=None):
   """This function, Fire, is the main entrypoint for Python Fire.
 
   Executes a command either from the `command` argument or from sys.argv by
@@ -164,7 +164,7 @@ def Fire(component=None, command=None, name=None, formatter=None):
     raise FireExit(0, component_trace)
 
   # The command succeeded normally; print the result.
-  _PrintResult(component_trace, verbose=component_trace.verbose, formatter=formatter)
+  _PrintResult(component_trace, verbose=component_trace.verbose, serialize=serialize)
   result = component_trace.GetResult()
   return result
 
@@ -241,7 +241,7 @@ def _IsHelpShortcut(component_trace, remaining_args):
   return show_help
 
 
-def _PrintResult(component_trace, verbose=False, formatter=None):
+def _PrintResult(component_trace, verbose=False, serialize=None):
   """Prints the result of the Fire call to stdout in a human readable way."""
   # TODO(dbieber): Design human readable deserializable serialization method
   # and move serialization to its own module.
@@ -249,8 +249,8 @@ def _PrintResult(component_trace, verbose=False, formatter=None):
 
   # Allow users to modify the return value of the component and provide 
   # custom formatting.
-  if callable(formatter):
-    result = formatter(result)
+  if callable(serialize):
+    result = serialize(result)
 
   if value_types.HasCustomStr(result):
     # If the object has a custom __str__ method, rather than one inherited from

--- a/fire/core.py
+++ b/fire/core.py
@@ -78,7 +78,7 @@ if six.PY34:
   import asyncio  # pylint: disable=import-error,g-import-not-at-top  # pytype: disable=import-error
 
 
-def Fire(component=None, command=None, name=None):
+def Fire(component=None, command=None, name=None, formatter=None):
   """This function, Fire, is the main entrypoint for Python Fire.
 
   Executes a command either from the `command` argument or from sys.argv by
@@ -164,7 +164,7 @@ def Fire(component=None, command=None, name=None):
     raise FireExit(0, component_trace)
 
   # The command succeeded normally; print the result.
-  _PrintResult(component_trace, verbose=component_trace.verbose)
+  _PrintResult(component_trace, verbose=component_trace.verbose, formatter=formatter)
   result = component_trace.GetResult()
   return result
 
@@ -241,11 +241,16 @@ def _IsHelpShortcut(component_trace, remaining_args):
   return show_help
 
 
-def _PrintResult(component_trace, verbose=False):
+def _PrintResult(component_trace, verbose=False, formatter=None):
   """Prints the result of the Fire call to stdout in a human readable way."""
   # TODO(dbieber): Design human readable deserializable serialization method
   # and move serialization to its own module.
   result = component_trace.GetResult()
+
+  # Allow users to modify the return value of the component and provide 
+  # custom formatting.
+  if callable(formatter):
+    result = formatter(result)
 
   if value_types.HasCustomStr(result):
     # If the object has a custom __str__ method, rather than one inherited from

--- a/fire/core.py
+++ b/fire/core.py
@@ -251,7 +251,7 @@ def _PrintResult(component_trace, verbose=False, serialize=None):
   # custom formatting.
   if serialize:
     if not callable(serialize):
-      raise FireError("serialize must be callable.")
+      raise FireError("serialize argument {} must be empty or callable.".format(serialize))
     result = serialize(result)
 
   if value_types.HasCustomStr(result):

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -200,14 +200,20 @@ class CoreTest(testutils.BaseTestCase):
         return ', '.join(str(xi) for xi in x)
       if isinstance(x, dict):
         return ', '.join('{}={!r}'.format(k, v) for k, v in x.items())
+      if x == 'special':
+        return 'SURPRISE!!'
       return x
+
+    ident = lambda x: x
     
     with self.assertOutputMatches(stdout='a, b', stderr=None):
-      result = core.Fire(lambda x: list(x), command=['[a,b]'], formatter=formatter)
+      result = core.Fire(ident, command=['[a,b]'], formatter=formatter)
     with self.assertOutputMatches(stdout='a=5, b=6', stderr=None):
-      result = core.Fire(lambda x: dict(x), command=['{a:5,b:6}'], formatter=formatter)
+      result = core.Fire(ident, command=['{a:5,b:6}'], formatter=formatter)
     with self.assertOutputMatches(stdout='asdf', stderr=None):
-      result = core.Fire(lambda x: str(x), command=['asdf'], formatter=formatter)
+      result = core.Fire(ident, command=['asdf'], formatter=formatter)
+    with self.assertOutputMatches(stdout='SURPRISE!!', stderr=None):
+      result = core.Fire(ident, command=['special'], formatter=formatter)
 
 
   @testutils.skipIf(six.PY2, 'lru_cache is Python 3 only.')

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -194,6 +194,22 @@ class CoreTest(testutils.BaseTestCase):
         7,
     )
 
+  def testCustomFormatter(self):
+    def formatter(x):
+      if isinstance(x, list):
+        return ', '.join(str(xi) for xi in x)
+      if isinstance(x, dict):
+        return ', '.join('{}={!r}'.format(k, v) for k, v in x.items())
+      return x
+    
+    with self.assertOutputMatches(stdout='a, b', stderr=None):
+      result = core.Fire(lambda x: list(x), command=['[a,b]'], formatter=formatter)
+    with self.assertOutputMatches(stdout='a=5, b=6', stderr=None):
+      result = core.Fire(lambda x: dict(x), command=['{a:5,b:6}'], formatter=formatter)
+    with self.assertOutputMatches(stdout='asdf', stderr=None):
+      result = core.Fire(lambda x: str(x), command=['asdf'], formatter=formatter)
+
+
   @testutils.skipIf(six.PY2, 'lru_cache is Python 3 only.')
   def testLruCacheDecoratorBoundArg(self):
     self.assertEqual(

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -194,8 +194,8 @@ class CoreTest(testutils.BaseTestCase):
         7,
     )
 
-  def testCustomFormatter(self):
-    def formatter(x):
+  def testCustomSerialize(self):
+    def serialize(x):
       if isinstance(x, list):
         return ', '.join(str(xi) for xi in x)
       if isinstance(x, dict):
@@ -207,13 +207,13 @@ class CoreTest(testutils.BaseTestCase):
     ident = lambda x: x
     
     with self.assertOutputMatches(stdout='a, b', stderr=None):
-      result = core.Fire(ident, command=['[a,b]'], formatter=formatter)
+      result = core.Fire(ident, command=['[a,b]'], serialize=serialize)
     with self.assertOutputMatches(stdout='a=5, b=6', stderr=None):
-      result = core.Fire(ident, command=['{a:5,b:6}'], formatter=formatter)
+      result = core.Fire(ident, command=['{a:5,b:6}'], serialize=serialize)
     with self.assertOutputMatches(stdout='asdf', stderr=None):
-      result = core.Fire(ident, command=['asdf'], formatter=formatter)
+      result = core.Fire(ident, command=['asdf'], serialize=serialize)
     with self.assertOutputMatches(stdout="SURPRISE!!\nI'm a list!\n", stderr=None):
-      result = core.Fire(ident, command=['special'], formatter=formatter)
+      result = core.Fire(ident, command=['special'], serialize=serialize)
 
 
   @testutils.skipIf(six.PY2, 'lru_cache is Python 3 only.')

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -201,7 +201,7 @@ class CoreTest(testutils.BaseTestCase):
       if isinstance(x, dict):
         return ', '.join('{}={!r}'.format(k, v) for k, v in x.items())
       if x == 'special':
-        return 'SURPRISE!!'
+        return ['SURPRISE!!', "I'm a list!"]
       return x
 
     ident = lambda x: x
@@ -212,7 +212,7 @@ class CoreTest(testutils.BaseTestCase):
       result = core.Fire(ident, command=['{a:5,b:6}'], formatter=formatter)
     with self.assertOutputMatches(stdout='asdf', stderr=None):
       result = core.Fire(ident, command=['asdf'], formatter=formatter)
-    with self.assertOutputMatches(stdout='SURPRISE!!', stderr=None):
+    with self.assertOutputMatches(stdout="SURPRISE!!\nI'm a list!\n", stderr=None):
       result = core.Fire(ident, command=['special'], formatter=formatter)
 
 

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -214,6 +214,8 @@ class CoreTest(testutils.BaseTestCase):
       result = core.Fire(ident, command=['asdf'], serialize=serialize)
     with self.assertOutputMatches(stdout="SURPRISE!!\nI'm a list!\n", stderr=None):
       result = core.Fire(ident, command=['special'], serialize=serialize)
+    with self.assertRaises(core.FireError):
+      core.Fire(ident, command=['asdf'], serialize=55)
 
 
   @testutils.skipIf(six.PY2, 'lru_cache is Python 3 only.')


### PR DESCRIPTION
Fixes #344 (see issue for more details)

This lets you define a function that will take the result from the Fire component and allows the user to alter it before fire looks at it to render it. 

**Why?** Because you want to define a global way of formatting your data for your CLI across a family of functions/classes where it is impractical (and a **major pain**) to wrap them all.

### Outputting tabular data:
```python
import random
def data():
    return [
        {
            'is_up': random.choice([False, True]), 
            'value_A': random.random(), 
            'value_B': random.random() + 100,
            'id': random.randint(1000, 5000)} 
        for i in range(8)
    ]

import fire
fire.Fire(data)
```
Outputs this:
```
{"is_up": true, "value_A": 0.6004291859538904, "value_B": 100.77910907893889, "id": 474}
{"is_up": false, "value_A": 0.1406617230697117, "value_B": 100.35721554966845, "id": 740}
{"is_up": true, "value_A": 0.3612392830626744, "value_B": 100.60814663568802, "id": 509}
{"is_up": false, "value_A": 0.11247653550250092, "value_B": 100.2673181440675, "id": 305}
{"is_up": false, "value_A": 0.9505598630828166, "value_B": 100.84615141986525, "id": 85}
{"is_up": true, "value_A": 0.17544933002396768, "value_B": 100.66062056951291, "id": 385}
{"is_up": false, "value_A": 0.25245927587860695, "value_B": 100.75492369068093, "id": 923}
{"is_up": true, "value_A": 0.9237200249249168, "value_B": 100.94228120845642, "id": 702}
```
But if we can define a formatter.
```python
import tabulate

def fancy_table(result):
    if not result:  # show a message instead of an empty response
        return 'nada. sorry.'
    
    # display a list of dicts as a table
    if isinstance(result, (list, tuple)) and all(isinstance(x, dict) for x in result):
        return tabulate.tabulate([
            {col: cell_format(value) for col, value in row.items()}
            for row in result
        ], headers="keys")

    return result  # otherwise, let fire handle it

def cell_format(value, decimals=3, bool=('🌹', '🥀')):
    if value is True:
        return bool[0]
    if value is False:
        return bool[1]
    if isinstance(value, float):
        return '{:.{}f}'.format(value, decimals)
    return value

fire.Fire(data, formatter=fancy_table)
```
Outputs this:
```
is_up      value_A    value_B    id
-------  ---------  ---------  ----
🌹           0.115    100.013  1821
🌹           0.439    100.167  4242
🥀           0.68     100.345  2937
🥀           0.074    100.119  4675
🌹           0.189    100.462  4571
🌹           0.221    100.342  1522
🌹           0.02     100.452  2363
🥀           0.023    100.812  2433
```

Using a formatter means that:
 - if you don't provide a formatter, or if your formatter returns the original value (`lambda x: x`) then nothing is changed
 - if you want to change how some value is displayed, you can just return what you want it to render as
   e.g. `lambda x: {'idk why, but': x} if isinstance(x, list) else x`
 - if you are unable to make a class `__str__` representation look like you want it to, you can handle it in the formatter instead
   e.g. `lambda x: custom_str(x) if isinstance(x, some_class) else x`
 - if you want to display nested dictionaries as yaml, you can use `yaml.dump` as a formatter
 - you can suppress output  e.g. `lambda x: None`
 - you can handle printing yourself by printing inside the formatter and returning None to suppress fire formatting
