### PR TITLE
Interactive mode: Mention IPython REPL requirement

### DIFF
--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -137,6 +137,9 @@ will put you in an IPython REPL, with the variable `widget` already defined.
 You can then explore the Python object that `widget` corresponds to
 interactively using Python.
 
+Note: if you want fire to start the IPython REPL instead of the regular Python one,
+the `ipython` package needs to be installed in your environment.
+
 
 ### `--completion`: Generating a completion script <a name="completion-flag"></a>
 


### PR DESCRIPTION
Mention that the ipython package is an optional requirement for using the IPython REPL, as described in the [source file](https://github.com/google/python-fire/blob/master/fire/interact.py#L17).