### PR TITLE
Move python 3 only component to test_components_py3.py

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -29,16 +29,10 @@ python -m pytest  # Run the tests without IPython.
 pip install ipython
 python -m pytest  # Now run the tests with IPython.
 pylint fire --ignore=test_components_py3.py,parser_fuzz_test.py,console
-if [[ ${PYTHON_VERSION} == 2.7 || ${PYTHON_VERSION} == 3.7 ]]; then
+if [[ ${PYTHON_VERSION} == 3.7 ]]; then
   pip install pytype;
 fi
-# Run type-checking, excluding files that define or use py3 features in py2.
-if [[ ${PYTHON_VERSION} == 2.7 ]]; then
-  pytype -x \
-    fire/fire_test.py \
-    fire/inspectutils_test.py \
-    fire/test_components_py3.py;
-elif [[ ${PYTHON_VERSION} == 3.7 ]]; then
+# Run type-checking.
+if [[ ${PYTHON_VERSION} == 3.7 ]]; then
   pytype -x fire/test_components_py3.py;
 fi
-

--- a/fire/helptext_test.py
+++ b/fire/helptext_test.py
@@ -497,6 +497,9 @@ class UsageTest(testutils.BaseTestCase):
         textwrap.dedent(expected_output).lstrip('\n'),
         usage_output)
 
+  @testutils.skipIf(
+      six.PY2,
+      'Python 2 does not support required name-only arguments.')
   def testUsageOutputFunctionMixedDefaults(self):
     component = tc.py3.HelpTextComponent().identity
     t = trace.FireTrace(component, name='FunctionMixedDefaults')

--- a/fire/helptext_test.py
+++ b/fire/helptext_test.py
@@ -498,7 +498,7 @@ class UsageTest(testutils.BaseTestCase):
         usage_output)
 
   def testUsageOutputFunctionMixedDefaults(self):
-    component = tc.MixedDefaults().identity2
+    component = tc.py3.HelpTextComponent().identity
     t = trace.FireTrace(component, name='FunctionMixedDefaults')
     usage_output = helptext.UsageText(component, trace=t, verbose=False)
     expected_output = """

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -133,9 +133,6 @@ class MixedDefaults(object):
   def identity(self, alpha, beta='0'):
     return alpha, beta
 
-  def identity2(self, *, alpha, beta='0'):
-    return alpha, beta
-
 
 class SimilarArgNames(object):
 

--- a/fire/test_components_py3.py
+++ b/fire/test_components_py3.py
@@ -25,6 +25,12 @@ def identity(arg1, arg2: int, arg3=10, arg4: int = 20, *arg5,
   return arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10
 
 
+class HelpTextComponent:
+
+  def identity(self, *, alpha, beta='0'):
+    return alpha, beta
+
+
 class KeywordOnly(object):
 
   def double(self, *, count):


### PR DESCRIPTION
#316 adds a test using Python 3 only features; this CL makes that test only run for Python 3 versions.