### PR TITLE
docs: Fix a few typos

### DIFF
--- a/fire/console/console_attr.py
+++ b/fire/console/console_attr.py
@@ -288,7 +288,7 @@ class ConsoleAttr(object):
     elif self._encoding == 'cp437' and not is_screen_reader:
       self._box_line_characters = BoxLineCharactersUnicode()
       self._bullets = self._BULLETS_WINDOWS
-      # Windows does not suport the unicode characters used for the spinner.
+      # Windows does not support the unicode characters used for the spinner.
       self._progress_tracker_symbols = ProgressTrackerSymbolsAscii()
     else:
       self._box_line_characters = BoxLineCharactersAscii()
@@ -456,7 +456,7 @@ class ConsoleAttr(object):
     return self._get_raw_key[0]()
 
   def GetTermIdentifier(self):
-    """Returns the TERM envrionment variable for the console.
+    """Returns the TERM environment variable for the console.
 
     Returns:
       str: A str that describes the console's text capabilities

--- a/fire/custom_descriptions.py
+++ b/fire/custom_descriptions.py
@@ -28,7 +28,7 @@ dict(iterable) -> new dictionary initialized as if via:
 dict(**kwargs) -> new dictionary initialized with the name=value pairs
     in the keyword argument list.  For example:  dict(one=1, two=2)
 
-As you can see, this docstring is more pertinant to the function `dict` and
+As you can see, this docstring is more pertinent to the function `dict` and
 would be suitable as the result of `dict.__doc__`, but is wholely unsuitable
 as a description for the dict `{'key': 'value'}`.
 


### PR DESCRIPTION
There are small typos in:
- fire/console/console_attr.py
- fire/custom_descriptions.py

Fixes:
- Should read `support` rather than `suport`.
- Should read `pertinent` rather than `pertinant`.
- Should read `environment` rather than `envrionment`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md