### PR TITLE
fix using a Class for grouping commands --self shows as a flag

### DIFF
--- a/fire/completion.py
+++ b/fire/completion.py
@@ -404,7 +404,13 @@ def Completions(component, verbose=False):
   Returns:
     A list of completions for a command that would so far return the component.
   """
-  if inspect.isroutine(component) or inspect.isclass(component):
+  if inspect.isroutine(component):
+    spec = inspectutils.GetFullArgSpec(component)
+    if len(component.__qualname__.split('.')) > 1 and 'self' in spec.args:
+      spec.args.remove('self')
+    return _CompletionsFromArgs(spec.args + spec.kwonlyargs)
+
+  if inspect.isclass(component):
     spec = inspectutils.GetFullArgSpec(component)
     return _CompletionsFromArgs(spec.args + spec.kwonlyargs)
 


### PR DESCRIPTION
Hi!

Fix issue #382 

After a lot of research I found out that the only way (I'm 99% sure about this) of knowing if a function belongs to a class is using [\_\_qualname\_\_](https://docs.python.org/3/library/stdtypes.html#definition.__qualname__). The only issue I see with this solution is that [\_\_qualname\_\_](https://docs.python.org/3/library/stdtypes.html#definition.__qualname__) belongs to python 3.3 and newer versions.

Another solution that I can think of is to check and to remove the 'self' argument from every function, regardless of whether it belongs to a class or not. This solution will limit the user to not name the argument from a function, that doesn't belong to a class, 'self'.

Let me know what you think and I'll be happy to make the changes, as well as to make any correction :)