### PR TITLE
Show default values for kwonly arguments in help text

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.7, 3.8, 3.9]
+        python-version: [2.7.18, 3.5.10, 3.7.15, 3.8.14, 3.9.15]
 
     steps:
      # Checkout the repo.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7.18, 3.5.10, 3.7.15, 3.8.14, 3.9.15]
+        python-version: [2.7, 3.5, 3.7, 3.8, 3.9]
 
     steps:
      # Checkout the repo.

--- a/fire/helptext.py
+++ b/fire/helptext.py
@@ -524,6 +524,8 @@ def _GetArgDefault(flag, spec):
   for arg, default in zip(args_with_defaults, spec.defaults):
     if arg == flag:
       return repr(default)
+  if flag in spec.kwonlydefaults:
+    return repr(spec.kwonlydefaults[flag])
   return ''
 
 

--- a/fire/helptext_test.py
+++ b/fire/helptext_test.py
@@ -296,6 +296,18 @@ class HelpTest(testutils.BaseTestCase):
     self.assertIn('NAME\n    double', output)
     self.assertIn('FLAGS\n    --count=COUNT (required)', output)
 
+  @testutils.skipIf(
+      six.PY2,
+      'Python 2 does not support required name-only arguments.')
+  def testHelpTextFunctionMixedDefaults(self):
+    component = tc.py3.HelpTextComponent().identity
+    t = trace.FireTrace(component, name='FunctionMixedDefaults')
+    output = helptext.HelpText(component, trace=t)
+    self.assertIn('NAME\n    FunctionMixedDefaults', output)
+    self.assertIn('FunctionMixedDefaults <flags>', output)
+    self.assertIn('--alpha=ALPHA (required)', output)
+    self.assertIn('--beta=BETA\n        Default: \'0\'', output)
+
   def testHelpScreen(self):
     component = tc.ClassWithDocstring()
     t = trace.FireTrace(component, name='ClassWithDocstring')


### PR DESCRIPTION
Fixes #410 

* Shows default values for kwonly arguments in help text
* Adds test verifying that default values are shown for kwonly args