### PR TITLE
Support case-insensitive usage

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -534,7 +534,7 @@ def _Fire(component, args, parsed_flag_args, context, name=None):
             in lowered_component_dict) and target != target.lower():
         print('NOTE: Consider using the correct capitalization for {}'.format(
             target))
-        error = FireError('Ambiguous member access:', target)
+        error = FireError('Ambiguous component access:', target)
         candidate_errors.append((error, initial_args))
       else:
         # The target isn't present in the dict as a string key, but maybe it is
@@ -671,6 +671,11 @@ def _GetMember(component, args):
       for member in members:
         if arg_name == member.lower():
           return getattr(component, member), [arg], args[1:]
+          # The member exists, but the capitalization is incorrect.
+        elif arg_name.lower() == member.lower():
+          print('NOTE: Consider using the correct capitalization for {}'.format(
+              arg_name))
+          raise FireError('Ambiguous member access:', arg_name)
 
   raise FireError('Could not consume arg:', arg)
 

--- a/fire/core.py
+++ b/fire/core.py
@@ -515,12 +515,27 @@ def _Fire(component, args, parsed_flag_args, context, name=None):
       else:
         component_dict = component
 
+      lowered_component_dict = dict((str(k).lower(), str(v).lower())
+                                    for k,v in component_dict.items())
+
       if target in component_dict:
         component = component_dict[target]
         handled = True
       elif target.replace('-', '_') in component_dict:
         component = component_dict[target.replace('-', '_')]
         handled = True
+      elif target in lowered_component_dict:
+        for key, value in component_dict.items():
+          if target == str(key).lower():
+            component = component_dict[key]
+            handled = True
+            break
+      elif (target.lower()
+            in lowered_component_dict) and target != target.lower():
+        print('NOTE: Consider using the correct capitalization for {}'.format(
+            target))
+        error = FireError('Ambiguous member access:', target)
+        candidate_errors.append((error, initial_args))
       else:
         # The target isn't present in the dict as a string key, but maybe it is
         # a key as another type.
@@ -652,6 +667,10 @@ def _GetMember(component, args):
   for arg_name in arg_names:
     if arg_name in members:
       return getattr(component, arg_name), [arg], args[1:]
+    else:
+      for member in members:
+        if arg_name == member.lower():
+          return getattr(component, member), [arg], args[1:]
 
   raise FireError('Could not consume arg:', arg)
 

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -503,6 +503,18 @@ class FireTest(testutils.BaseTestCase):
         fire.Fire(tc.CapitalizedArgNames,
                   command=['sum', '-D', '5', '-G', '10']), 15)
 
+  def testCaseInsensitiveUsage(self):
+    self.assertEqual(
+        fire.Fire(tc.CapitalizedFunctionNames, command=['alpha']), 'alpha')
+    self.assertEqual(
+        fire.Fire(tc.CapitalizedFunctionNames, command=['Alpha']), 'Alpha')
+    self.assertEqual(
+      fire.Fire(tc.CapitalizedFunctionNames,
+                command=['beta']), 'Beta')
+    with self.assertRaisesFireExit(2):
+      # Ambiguous member access
+      fire.Fire(tc.CapitalizedFunctionNames, command=['ALPHA'])
+
   def testBoolParsingWithNo(self):
     # In these examples --nothing always refers to the nothing argument:
     def fn1(thing, nothing):

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -148,6 +148,13 @@ class CapitalizedArgNames(object):
   def sum(self, Delta=1.0, Gamma=2.0):  # pylint: disable=invalid-name
     return Delta + Gamma
 
+class CapitalizedFunctionNames(object):
+  def alpha(self):
+    return 'alpha'
+  def Alpha(self):
+    return 'Alpha'
+  def Beta(self):
+    return 'Beta'
 
 class Annotations(object):
 


### PR DESCRIPTION
Refers to #43

Sample usage:

```python
import fire

class Example(object):
  def alpha(self):
    return 'alpha'
  def Alpha(self):
    return 'Alpha'
  def Beta(self):
    return 'Beta'

if __name__=='__main__':
	fire.Fire(Example)
```

```
$ python test.py alpha
alpha
```

```
$ python test.py Alpha
Alpha
```

```
$ python test.py beta
Beta
```

```
$ python test.py BETA
NOTE: Consider using the correct capitalization for BETA
ERROR: Ambiguous member access: BETA
Usage: test.py <command>
  available commands:    Alpha | Beta | alpha

For detailed information on this command, run:
  test.py --help
```
