### PR TITLE
adding python 3.10 [tag & CI]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: Python Fire
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.7, 3.8, 3.9]
+        python-version: ["2.7", "3.5", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
      # Checkout the repo.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Python Fire
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
 
         'Operating System :: OS Independent',
         'Operating System :: POSIX',


### PR DESCRIPTION
I believe that Fire is fully compatible with all new Python versions so:
- adding tags to package
- adding testing for them