### PR TITLE
freeze CI requirements

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -19,11 +19,7 @@ set -e
 
 PYTHON_VERSION=${PYTHON_VERSION:-2.7}
 
-pip install --upgrade setuptools pip
-pip install --upgrade pylint pytest pytest-pylint pytest-runner
-pip install termcolor
-pip install hypothesis python-Levenshtein
-pip install mock
+pip install -U -r requirements.txt
 python setup.py develop
 python -m pytest  # Run the tests without IPython.
 pip install ipython

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,0 +1,10 @@
+setuptools <65.7.0
+pip <23.0
+pylint <3.0.0
+pytest <=7.2.1
+pytest-pylint <=1.1.2
+pytest-runner <6.0.0
+termcolor <2.2.0
+hypothesis <6.62.0
+python-Levenshtein <0.20.9
+mock <5.0.0

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,6 +1,6 @@
 setuptools <65.7.0
 pip <23.0
-pylint <3.0.0
+pylint <2.15.10
 pytest <=7.2.1
 pytest-pylint <=1.1.2
 pytest-runner <6.0.0


### PR DESCRIPTION
I would suggest to frezee CI depencies to limit accidental test failing die to unrelated changes... as I see failing tests in https://github.com/google/python-fire/pull/428#issuecomment-1412539465 without touching anything significant
so these versions are set as of Dec 2022 as that was last :green_circle: commit to the main branch
in the next PR #432 we can add dependabot, which is GitHub build-in mechanism to keep dependencies safely bumped...