### PR TITLE
adding GH dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,12 @@ version: 2
 updates:
   # Enable version updates for python
   - package-ecosystem: "pip"
-    # Look for a `requirements` in the `root` directory
     directory: ".github/scripts/"
-    # Check for updates once a week
     schedule:
       interval: "monthly"
-    # Labels on pull requests for version updates only
-    labels:
-      - "ci"
+    labels: ["ci"]
     pull-request-branch-name:
-      # Separate sections of the branch name with a hyphen
-      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
       separator: "-"
-    # Allow up to 5 open pull requests for pip dependencies
     open-pull-requests-limit: 5
     reviewers:
       - "dbieber"
@@ -24,21 +17,15 @@ updates:
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    # Check for updates once a week
     schedule:
       interval: "monthly"
     groups:
       pip:
         patterns:
           - "*"  # Check all dependencies
-    # Labels on pull requests for version updates only
-    labels:
-      - "ci"
+    labels: ["ci"]
     pull-request-branch-name:
-      # Separate sections of the branch name with a hyphen
-      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
       separator: "-"
-    # Allow up to 5 open pull requests for GitHub Actions
     open-pull-requests-limit: 5
     reviewers:
       - "dbieber"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "monthly"
+    groups:
+      pip:
+        patterns:
+          - "*"  # Check all dependencies
     # Labels on pull requests for version updates only
     labels:
       - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Basic dependabot.yml file with minimum configuration for two package managers
+
+version: 2
+updates:
+  # Enable version updates for python
+  - package-ecosystem: "pip"
+    # Look for a `requirements` in the `root` directory
+    directory: ".github/scripts/"
+    # Check for updates once a week
+    schedule:
+      interval: "monthly"
+    # Labels on pull requests for version updates only
+    labels:
+      - "ci"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"
+    # Allow up to 5 open pull requests for pip dependencies
+    open-pull-requests-limit: 5
+    reviewers:
+      - "dbieber"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "monthly"
+    # Labels on pull requests for version updates only
+    labels:
+      - "ci"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"
+    # Allow up to 5 open pull requests for GitHub Actions
+    open-pull-requests-limit: 5
+    reviewers:
+      - "dbieber"


### PR DESCRIPTION
This is a follow-up work of #431 to safely bump versions via PR, also triggering all CI to ensure development stability...