### PR TITLE
Fix deprecation warning: LICENSE is autodetected

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-license-file = LICENSE
-
 [wheel]
 universal = 1
 


### PR DESCRIPTION
This can be omitted entirely because setuptools automatically includes `LICENSE`:

> A list of glob patterns for license related files that should be included. If neither license_file nor license_files is specified, this option defaults to `LICEN[CS]E*`, `COPYING*`, `NOTICE*`, and `AUTHORS*`.

https://setuptools.pypa.io/en/latest/references/keywords.html#keywords

# Before

```console
$ python setup.py --licence
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/setuptools/dist.py:775: UserWarning: Usage of dash-separated 'license-file' will not be supported in future versions. Please use the underscore name 'license_file' instead
  warnings.warn(
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/setuptools/config/setupcfg.py:520: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
  warnings.warn(msg, warning_class)
Apache Software License
```

# After

```console
$ python setup.py --licence
Apache Software License
```
