### PR TITLE
ci: watcher for automerge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Python Fire
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Python Fire
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: ["master"]
 
-
 defaults:
   run:
     shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,17 @@ jobs:
        run: ./.github/scripts/build.sh
        env:
          PYTHON_VERSION: ${{ matrix.python-version }}
+
+  watcher:
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+    - run: echo "${{ needs.build.result }}"
+    - name: failing...
+      if: needs.build.result == 'failure'
+      run: exit 1
+    - name: cancelled or skipped...
+      if: contains(fromJSON('["cancelled", "skipped"]'), needs.build.result)
+      timeout-minutes: 1
+      run: sleep 90


### PR DESCRIPTION
As discussed in https://github.com/google/python-fire/pull/428#issuecomment-1413497193 adding a closure job would allow enabling automerge without need of updating branch protection checks when new Python version is added