### PR TITLE
Fix pandas.DataFrame support in core._PrintResult

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -262,6 +262,13 @@ def _PrintResult(component_trace, verbose=False, serialize=None):
     print(str(result))
     return
 
+  elif value_types.HasCustomRepr(result):
+    # Same as above, but for __repr__.
+    # For pandas.DataFrame, __str__ is inherited from object, but __repr__ has
+    # a custom implementation (see pandas.core.frame.DataFrame.__repr__)
+    print(str(result))
+    return
+
   if isinstance(result, (list, set, frozenset, types.GeneratorType)):
     for i in result:
       print(_OneLineResult(i))

--- a/fire/value_types.py
+++ b/fire/value_types.py
@@ -83,3 +83,21 @@ def HasCustomStr(component):
     if str_attr and str_attr.defining_class is not object:
       return True
   return False
+
+def HasCustomRepr(component):
+  """Reproduces above HasCustomStr function to determine if component has a 
+  custom __repr__ method.
+  
+  ...
+  
+  Args:
+    component: The object to check for a custom __repr__ method.
+  Returns:
+    Whether `component` has a custom __repr__ method.
+  """
+  if hasattr(component, '__repr__'):
+    class_attrs = inspectutils.GetClassAttrsDict(type(component)) or {}
+    repr_attr = class_attrs.get('__repr__')
+    if repr_attr and repr_attr.defining_class is not object:
+      return True
+  return False


### PR DESCRIPTION
+ and add `HasCustomRepr` check in value_types

**Issue**: 
When calling `Fire` on a function that returns a pd.DataFrame, the _PrintResult function in core.py prints the manual for DataFrames from the pandas Docs to stdout. 

Since `if value_types.HasCustomStr(result):` doesn't recognize the DataFrame's custom \_\_str__ as it is simply seemingly inherited from the custom \_\_repr__ for DataFrames (see pandas.core.frame.DataFrame.\_\_repr__), the `_PrintResult` function displays the DataFrame's `helptext.HelpText` instead.

This implementation should fix the issue. 