### PR TITLE
Fix missing `$` sign in bash completion

### DIFF
--- a/fire/completion.py
+++ b/fire/completion.py
@@ -104,7 +104,7 @@ filter_options()
 option_already_entered()
 {{
   local opt
-  for opt in ${{COMP_WORDS[@]:0:COMP_CWORD}}
+  for opt in ${{COMP_WORDS[@]:0:$COMP_CWORD}}
   do
     if [ $1 == $opt ]; then
       return 0


### PR DESCRIPTION
Related issue  https://github.com/google/python-fire/issues/64