### PR TITLE
Update formatting_windows.py

### DIFF
--- a/fire/formatting_windows.py
+++ b/fire/formatting_windows.py
@@ -35,7 +35,7 @@ def initialize_or_disable():
   """Enables ANSI processing on Windows or disables it as needed."""
   if HAS_COLORAMA:
     wrap = True
-    if sys.stdout.isatty() and platform.release() == '10':
+    if hasattr(sys.stdout, "isatty") and sys.stdout.isatty() and platform.release() == '10':
       # Enables native ANSI sequences in console.
       # Windows 10, 2016, and 2019 only.
 


### PR DESCRIPTION
When running Fire with PyInstaller on Windows by setting the option "console=False" in SPEC file "pyinstaller.spec" (see below) the executable dont work.

PyInstaller SPEC file

```
PyInstaller Spec File
exe = EXE(
    pyz,
    a.scripts,
    [],
    exclude_binaries=True,
    name='VHTools',
    debug=False,
    bootloader_ignore_signals=False,
    strip=False,
    upx=True,
    >>>    console=False,
    disable_windowed_traceback=False,
    argv_emulation=False,
    target_arch=None,
    codesign_identity=None,
    entitlements_file=None,
)
```

Below we have the executable message released:

```
Traceback (most recent call last):
  File "app.py", line 160, in <module>
    import fire
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "fire\__init__.py", line 21, in <module>
    from fire.core import Fire
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "fire\core.py", line 67, in <module>
    from fire import formatting
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "fire\formatting.py", line 21, in <module>
    from fire import formatting_windows  # pylint: disable=unused-import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 419, in exec_module
  File "fire\formatting_windows.py", line 60, in <module>
    initialize_or_disable()
  File "fire\formatting_windows.py", line 38, in initialize_or_disable
    if sys.stdout.isatty() and platform.release() == '10':
AttributeError: 'NoneType' object has no attribute 'isatty'
```
The Fire code in "formatting_windows.py" invoques an "isatty()" function that does not exists in "sys.stdout" in Python 3.9.

```
if sys.stdout.isatty() and platform.release() == '10':
```

To resolve the release, I check if the "isatty" member exists in the "sys.stdout" object.

```
if hasattr(sys.stdout, "isatty") and sys.stdout.isatty() and platform.release() == '10':
```

**IMPORTANT**
1) The error doent occur in all version of Python and I dont no why, but in "Python 3.9.2rc1" it does.
2) The error does not say null anywhere, it says the attribute isatty was not found in function
3) I found this same error in other cases on Google.
