### PR TITLE
ci: expand build matrix for major OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,22 @@ name: Python Fire
 
 on: [push]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.5", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        fail-fast: false
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          # adding some specific/older versions to the matrix
+          - {os: "ubuntu-20.04", python-version: "3.5"}
+          - {os: "ubuntu-20.04", python-version: "3.7"}
 
     steps:
      # Checkout the repo.
@@ -22,7 +32,6 @@ jobs:
 
      # Build Python Fire using the build.sh script.
      - name: Run build script
-       shell: bash
        run: ./.github/scripts/build.sh
        env:
          PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        fail-fast: false
         os: ["windows-latest", "macos-latest", "ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         fail-fast: false
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["windows-latest", "macos-latest", "ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           # adding some specific/older versions to the matrix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["windows-latest", "macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
         include:
           - {os: "ubuntu-20.04", python-version: "3.7"}


### PR DESCRIPTION
I suggest including testing on Mac and Win. 
also, the addition of OS builds does not need to be so extensive and could be listed in the `include` section adding 3.8 as the oldest and 3.12 as the latest python version