### PR TITLE
Verbose help message on objects when possible: No flags and --help flag consistent behavior

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -446,8 +446,20 @@ def _Fire(component, args, parsed_flag_args, context, name=None):
       break
 
     if _IsHelpShortcut(component_trace, remaining_args):
+      # Check to see if the class requires values in it's init function
       remaining_args = []
-      break
+
+      # If the object has an __init__ method, that takes no arguments besides
+      # self, dont break yet
+      if not hasattr(component, '__dict__'):
+        break
+      if '__init__' not in component.__dict__:
+        break
+      parameter_count = component.__dict__['__init__'].__code__.co_argcount  - 1
+
+      # If the __init__ method does takes arguments break
+      if parameter_count != 0:
+        break
 
     saved_args = []
     used_separator = False


### PR DESCRIPTION
**Issue:**
Fixes https://github.com/google/python-fire/issues/438

Given an object that has no __init__ method, or the __init__ method takes no arguments besides self passing a '--help' flag results in a **less** verbose help message than if no flag was passed at all.


**Cause:**
- When --help flag is provided, an object is not instantiated so the help message is less verbose
- When no flag is provided, and the class requires no arguments, an object is instantiated so the help message is more verbose

**Fix:**
A check to see if the object contains an __init__ method, and whether or not the __init__ method requires arguments fixes this. If no arguments are required, instantiate an object then show the help message. 