### PR TITLE
Use ast.Constant for recent Python versions

### DIFF
--- a/fire/parser.py
+++ b/fire/parser.py
@@ -20,7 +20,12 @@ from __future__ import print_function
 
 import argparse
 import ast
+import sys
 
+if sys.version_info[0:2] < (3, 8):
+  _StrNode = ast.Str
+else:
+  _StrNode = ast.Constant
 
 def CreateParser():
   parser = argparse.ArgumentParser(add_help=False)
@@ -127,4 +132,4 @@ def _Replacement(node):
   # These are the only builtin constants supported by literal_eval.
   if value in ('True', 'False', 'None'):
     return node
-  return ast.Str(value)
+  return _StrNode(value)


### PR DESCRIPTION
ast.Str is planned to removed in Python 3.14, use ast.Constant instead whenever the later is available.

This PR resolves #523, if that's an issue. :joy_cat: 

All test cases are passed and the pylint score is not changed.

> Your code has been rated at 9.87/10 (previous run: 9.87/10, +0.00)