### PR TITLE
Remove future imports now that we've dropped support for Python 2

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -17,7 +17,7 @@
 # Exit when any command fails.
 set -e
 
-PYTHON_VERSION=${PYTHON_VERSION:-2.7}
+PYTHON_VERSION=${PYTHON_VERSION:-3.7}
 
 pip install -U -r .github/scripts/requirements.txt
 python setup.py develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.5", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
      # Checkout the repo.

--- a/fire/__init__.py
+++ b/fire/__init__.py
@@ -14,10 +14,6 @@
 
 """The Python Fire module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire.core import Fire
 
 __all__ = ['Fire']

--- a/fire/__main__.py
+++ b/fire/__main__.py
@@ -18,10 +18,6 @@
 This allows using Fire with third-party libraries without modifying their code.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import importlib
 import os
 import sys

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -14,10 +14,6 @@
 
 """Provides tab completion functionality for CLIs built with Fire."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import copy
 import inspect

--- a/fire/completion.py
+++ b/fire/completion.py
@@ -14,6 +14,10 @@
 
 """Provides tab completion functionality for CLIs built with Fire."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import collections
 import copy
 import inspect

--- a/fire/completion_test.py
+++ b/fire/completion_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the completion module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import completion
 from fire import test_components as tc
 from fire import testutils

--- a/fire/console/console_io.py
+++ b/fire/console/console_io.py
@@ -15,10 +15,6 @@
 
 """General console printing utilities used by the Cloud SDK."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import signal
 import subprocess

--- a/fire/core.py
+++ b/fire/core.py
@@ -49,10 +49,6 @@ The available flags for all Fire CLIs are:
   --trace: Get the Fire Trace for the command.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import inspect
 import json
 import os

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the core module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import core
 from fire import test_components as tc
 from fire import testutils

--- a/fire/custom_descriptions.py
+++ b/fire/custom_descriptions.py
@@ -36,10 +36,6 @@ This modules aims to resolve that problem, providing custom summaries and
 descriptions for primitive typed values.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import formatting
 import six
 

--- a/fire/custom_descriptions_test.py
+++ b/fire/custom_descriptions_test.py
@@ -14,10 +14,6 @@
 
 """Tests for custom description module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import custom_descriptions
 from fire import testutils
 

--- a/fire/decorators.py
+++ b/fire/decorators.py
@@ -18,10 +18,6 @@ SetParseFn and SetParseFns allow you to set the functions Fire uses for parsing
 command line arguments to client code.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import inspect
 
 FIRE_METADATA = 'FIRE_METADATA'

--- a/fire/decorators_test.py
+++ b/fire/decorators_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the decorators module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import core
 from fire import decorators
 from fire import testutils

--- a/fire/docstrings.py
+++ b/fire/docstrings.py
@@ -49,10 +49,6 @@ TODO(dbieber): Support these features.
 - "True | False" indicates bool type.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import enum
 import re

--- a/fire/docstrings_fuzz_test.py
+++ b/fire/docstrings_fuzz_test.py
@@ -14,10 +14,6 @@
 
 """Fuzz tests for the docstring parser module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import docstrings
 from fire import testutils
 

--- a/fire/docstrings_test.py
+++ b/fire/docstrings_test.py
@@ -14,10 +14,6 @@
 
 """Tests for fire docstrings module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import docstrings
 from fire import testutils
 

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the fire module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import sys
 

--- a/fire/formatting.py
+++ b/fire/formatting.py
@@ -14,10 +14,6 @@
 
 """Formatting utilities for use in creating help text."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import formatting_windows  # pylint: disable=unused-import
 import termcolor
 

--- a/fire/formatting_test.py
+++ b/fire/formatting_test.py
@@ -14,10 +14,6 @@
 
 """Tests for formatting.py."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import formatting
 from fire import testutils
 

--- a/fire/formatting_windows.py
+++ b/fire/formatting_windows.py
@@ -14,10 +14,6 @@
 
 """This module is used for enabling formatting on Windows."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import ctypes
 import os
 import platform

--- a/fire/helptext.py
+++ b/fire/helptext.py
@@ -29,10 +29,6 @@ Help screens are shown in a less-style console view, and contain detailed help
 information.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import itertools
 import sys

--- a/fire/helptext_test.py
+++ b/fire/helptext_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the helptext module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import sys
 import textwrap

--- a/fire/inspectutils.py
+++ b/fire/inspectutils.py
@@ -14,10 +14,6 @@
 
 """Inspection utility functions for Python Fire."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import inspect
 import sys
 import types

--- a/fire/inspectutils_test.py
+++ b/fire/inspectutils_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the inspectutils module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import unittest
 

--- a/fire/interact.py
+++ b/fire/interact.py
@@ -20,10 +20,6 @@ interactive flag will start a Python REPL with the builtin `code` module's
 InteractiveConsole class.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import inspect
 
 

--- a/fire/interact_test.py
+++ b/fire/interact_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the interact module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import interact
 from fire import testutils
 

--- a/fire/parser.py
+++ b/fire/parser.py
@@ -14,10 +14,6 @@
 
 """Provides parsing functionality used by Python Fire."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import argparse
 import ast
 import sys

--- a/fire/parser_fuzz_test.py
+++ b/fire/parser_fuzz_test.py
@@ -14,10 +14,6 @@
 
 """Fuzz tests for the parser module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import parser
 from fire import testutils
 from hypothesis import example

--- a/fire/parser_test.py
+++ b/fire/parser_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the parser module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import parser
 from fire import testutils
 

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -14,10 +14,6 @@
 
 """This module has components that are used for testing Python Fire."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import enum
 import functools

--- a/fire/test_components_bin.py
+++ b/fire/test_components_bin.py
@@ -17,10 +17,6 @@
 This file is useful for replicating test results manually.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import fire
 from fire import test_components
 

--- a/fire/test_components_test.py
+++ b/fire/test_components_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the test_components module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import test_components as tc
 from fire import testutils
 

--- a/fire/testutils.py
+++ b/fire/testutils.py
@@ -14,10 +14,6 @@
 
 """Utilities for Python Fire's tests."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import contextlib
 import os
 import re

--- a/fire/testutils_test.py
+++ b/fire/testutils_test.py
@@ -14,10 +14,6 @@
 
 """Test the test utilities for Fire's tests."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import sys
 
 from fire import testutils

--- a/fire/trace.py
+++ b/fire/trace.py
@@ -25,10 +25,6 @@ a function, then that error will be captured in the trace and the final
 component will be None.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import shlex
 
 from fire import inspectutils

--- a/fire/trace_test.py
+++ b/fire/trace_test.py
@@ -14,10 +14,6 @@
 
 """Tests for the trace module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from fire import testutils
 from fire import trace
 

--- a/fire/value_types.py
+++ b/fire/value_types.py
@@ -14,10 +14,6 @@
 
 """Types of values."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import inspect
 
 from fire import inspectutils

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ TEST_DEPENDENCIES = [
     'python-Levenshtein',
 ]
 
-VERSION = '0.6.0'
+VERSION = '0.7.0'
 URL = 'https://github.com/google/python-fire'
 
 setup(
@@ -63,11 +63,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
 
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This PR removes `from __future__` imports and drops support for Python 3.5 (since GitHub actions doesn't support it readily any more https://github.com/actions/setup-python/issues/866).