### PR TITLE
remove six: Replace six.string_types and six.integer_types, etc.

### DIFF
--- a/fire/completion.py
+++ b/fire/completion.py
@@ -23,7 +23,6 @@ import copy
 import inspect
 
 from fire import inspectutils
-import six
 
 
 def Script(name, component, default_options=None, shell='bash'):
@@ -308,7 +307,7 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
   Returns
     A boolean value indicating whether the member should be included.
   """
-  if isinstance(name, six.string_types) and name.startswith('__'):
+  if isinstance(name, str) and name.startswith('__'):
     return False
   if verbose:
     return True
@@ -316,10 +315,11 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
       or member is division
       or member is print_function):
     return False
-  if isinstance(member, type(absolute_import)) and six.PY34:
+  if isinstance(member, type(absolute_import)):
     return False
-  if inspect.ismodule(member) and member is six:
-    # TODO(dbieber): Determine more generally which modules to hide.
+  # TODO(dbieber): Determine more generally which modules to hide.
+  modules_to_hide = []
+  if inspect.ismodule(member) and member in modules_to_hide:
     return False
   if inspect.isclass(component):
     # If class_attrs has not been provided, compute it.
@@ -336,14 +336,7 @@ def MemberVisible(component, name, member, class_attrs=None, verbose=False):
       tuplegetter = getattr(collections, '_tuplegetter', type(None))
       if isinstance(class_attr.object, tuplegetter):
         return False
-  if (six.PY2 and inspect.isfunction(component)
-      and name in ('func_closure', 'func_code', 'func_defaults',
-                   'func_dict', 'func_doc', 'func_globals', 'func_name')):
-    return False
-  if (six.PY2 and inspect.ismethod(component)
-      and name in ('im_class', 'im_func', 'im_self')):
-    return False
-  if isinstance(name, six.string_types):
+  if isinstance(name, str):
     return not name.startswith('_')
   return True  # Default to including the member
 
@@ -438,7 +431,7 @@ def _FormatForCommand(token):
   Returns:
     The transformed token.
   """
-  if not isinstance(token, six.string_types):
+  if not isinstance(token, str):
     token = str(token)
 
   if token.startswith('_'):

--- a/fire/core.py
+++ b/fire/core.py
@@ -67,10 +67,8 @@ from fire import parser
 from fire import trace
 from fire import value_types
 from fire.console import console_io
-import six
 
-if six.PY34:
-  import asyncio  # pylint: disable=import-error,g-import-not-at-top  # pytype: disable=import-error
+import asyncio  # pylint: disable=import-error,g-import-not-at-top  # pytype: disable=import-error
 
 
 def Fire(component=None, command=None, name=None, serialize=None):
@@ -109,7 +107,7 @@ def Fire(component=None, command=None, name=None, serialize=None):
   name = name or os.path.basename(sys.argv[0])
 
   # Get args as a list.
-  if isinstance(command, six.string_types):
+  if isinstance(command, str):
     args = shlex.split(command)
   elif isinstance(command, (list, tuple)):
     args = command
@@ -344,7 +342,7 @@ def _DictAsString(result, verbose=False):
 def _OneLineResult(result):
   """Returns result serialized to a single line string."""
   # TODO(dbieber): Ensure line is fewer than eg 120 characters.
-  if isinstance(result, six.string_types):
+  if isinstance(result, str):
     return str(result).replace('\n', ' ')
 
   # TODO(dbieber): Show a small amount of usage information about the function

--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -20,8 +20,6 @@ from fire import testutils
 from fire import trace
 import mock
 
-import six
-
 
 class CoreTest(testutils.BaseTestCase):
 
@@ -214,13 +212,11 @@ class CoreTest(testutils.BaseTestCase):
     with self.assertRaises(core.FireError):
       core.Fire(ident, command=['asdf'], serialize=55)
 
-  @testutils.skipIf(six.PY2, 'lru_cache is Python 3 only.')
   def testLruCacheDecoratorBoundArg(self):
     self.assertEqual(
         core.Fire(tc.py3.LruCacheDecoratedMethod,  # pytype: disable=module-attr
                   command=['lru_cache_in_class', 'foo']), 'foo')
 
-  @testutils.skipIf(six.PY2, 'lru_cache is Python 3 only.')
   def testLruCacheDecorator(self):
     self.assertEqual(
         core.Fire(tc.py3.lru_cache_decorated,  # pytype: disable=module-attr

--- a/fire/custom_descriptions.py
+++ b/fire/custom_descriptions.py
@@ -37,7 +37,6 @@ descriptions for primitive typed values.
 """
 
 from fire import formatting
-import six
 
 TWO_DOUBLE_QUOTES = '""'
 STRING_DESC_PREFIX = 'The string '
@@ -60,13 +59,11 @@ def NeedsCustomDescription(component):
     Whether the component should use a custom description and summary.
   """
   type_ = type(component)
-  if (type_ in six.string_types
-      or type_ in six.integer_types
-      or type_ is six.text_type
-      or type_ is six.binary_type
+  if (
+      type_ in (str, int, bytes)
       or type_ in (float, complex, bool)
       or type_ in (dict, tuple, list, set, frozenset)
-     ):
+  ):
     return True
   return False
 

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -22,7 +22,6 @@ from fire import test_components as tc
 from fire import testutils
 
 import mock
-import six
 
 
 class FireTest(testutils.BaseTestCase):
@@ -180,7 +179,6 @@ class FireTest(testutils.BaseTestCase):
     self.assertEqual(fire.Fire(tc.Annotations, command=['double', '5']), 10)
     self.assertEqual(fire.Fire(tc.Annotations, command=['triple', '5']), 15)
 
-  @testutils.skipIf(six.PY2, 'Keyword-only arguments not in Python 2.')
   def testFireKeywordOnlyArgs(self):
     with self.assertRaisesFireExit(2):
       # Keyword arguments must be passed with flag syntax.
@@ -717,7 +715,6 @@ class FireTest(testutils.BaseTestCase):
     with self.assertRaisesFireExit(0):
       fire.Fire(tc.decorated_method, command=['--help'])
 
-  @testutils.skipIf(six.PY2, 'Asyncio not available in Python 2.')
   def testFireAsyncio(self):
     self.assertEqual(fire.Fire(tc.py3.WithAsyncio,
                                command=['double', '--count', '10']), 20)

--- a/fire/helptext_test.py
+++ b/fire/helptext_test.py
@@ -23,7 +23,6 @@ from fire import helptext
 from fire import test_components as tc
 from fire import testutils
 from fire import trace
-import six
 
 
 class HelpTest(testutils.BaseTestCase):
@@ -276,8 +275,6 @@ class HelpTest(testutils.BaseTestCase):
     self.assertIn('NAME\n    OldStyleEmpty', help_screen)
     self.assertIn('SYNOPSIS\n    OldStyleEmpty', help_screen)
 
-  @testutils.skipIf(
-      six.PY2, 'Python 2 does not support keyword-only arguments.')
   def testHelpTextKeywordOnlyArgumentsWithDefault(self):
     component = tc.py3.KeywordOnly.with_default  # pytype: disable=module-attr
     output = helptext.HelpText(
@@ -285,8 +282,6 @@ class HelpTest(testutils.BaseTestCase):
     self.assertIn('NAME\n    with_default', output)
     self.assertIn('FLAGS\n    -x, --x=X', output)
 
-  @testutils.skipIf(
-      six.PY2, 'Python 2 does not support keyword-only arguments.')
   def testHelpTextKeywordOnlyArgumentsWithoutDefault(self):
     component = tc.py3.KeywordOnly.double  # pytype: disable=module-attr
     output = helptext.HelpText(
@@ -294,9 +289,6 @@ class HelpTest(testutils.BaseTestCase):
     self.assertIn('NAME\n    double', output)
     self.assertIn('FLAGS\n    -c, --count=COUNT (required)', output)
 
-  @testutils.skipIf(
-      six.PY2,
-      'Python 2 does not support required name-only arguments.')
   def testHelpTextFunctionMixedDefaults(self):
     component = tc.py3.HelpTextComponent().identity
     t = trace.FireTrace(component, name='FunctionMixedDefaults')
@@ -523,9 +515,6 @@ class UsageTest(testutils.BaseTestCase):
         textwrap.dedent(expected_output).lstrip('\n'),
         usage_output)
 
-  @testutils.skipIf(
-      six.PY2,
-      'Python 2 does not support required name-only arguments.')
   def testUsageOutputFunctionMixedDefaults(self):
     component = tc.py3.HelpTextComponent().identity
     t = trace.FireTrace(component, name='FunctionMixedDefaults')

--- a/fire/inspectutils_test.py
+++ b/fire/inspectutils_test.py
@@ -15,7 +15,6 @@
 """Tests for the inspectutils module."""
 
 import os
-import unittest
 
 from fire import inspectutils
 from fire import test_components as tc

--- a/fire/inspectutils_test.py
+++ b/fire/inspectutils_test.py
@@ -21,8 +21,6 @@ from fire import inspectutils
 from fire import test_components as tc
 from fire import testutils
 
-import six
-
 
 class InspectUtilsTest(testutils.BaseTestCase):
 
@@ -36,7 +34,6 @@ class InspectUtilsTest(testutils.BaseTestCase):
     self.assertEqual(spec.kwonlydefaults, {})
     self.assertEqual(spec.annotations, {'arg2': int, 'arg4': int})
 
-  @unittest.skipIf(six.PY2, 'No keyword arguments in python 2')
   def testGetFullArgSpecPy3(self):
     spec = inspectutils.GetFullArgSpec(tc.py3.identity)
     self.assertEqual(spec.args, ['arg1', 'arg2', 'arg3', 'arg4'])
@@ -121,10 +118,7 @@ class InspectUtilsTest(testutils.BaseTestCase):
 
   def testInfoClassNoInit(self):
     info = inspectutils.Info(tc.OldStyleEmpty)
-    if six.PY2:
-      self.assertEqual(info.get('type_name'), 'classobj')
-    else:
-      self.assertEqual(info.get('type_name'), 'type')
+    self.assertEqual(info.get('type_name'), 'type')
     self.assertIn(os.path.join('fire', 'test_components.py'), info.get('file'))
     self.assertGreater(info.get('line'), 0)
 

--- a/fire/parser_fuzz_test.py
+++ b/fire/parser_fuzz_test.py
@@ -82,7 +82,7 @@ class ParserFuzzTest(testutils.BaseTestCase):
     if '#' in value:
       max_distance += len(value) - value.index('#')
 
-    if not isinstance(result, six.string_types):
+    if not isinstance(result, str):
       max_distance += value.count('0')  # Leading 0s are stripped.
 
     # Note: We don't check distance for dicts since item order can be changed.

--- a/fire/parser_fuzz_test.py
+++ b/fire/parser_fuzz_test.py
@@ -21,7 +21,6 @@ from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
 import Levenshtein
-import six
 
 
 class ParserFuzzTest(testutils.BaseTestCase):
@@ -64,8 +63,8 @@ class ParserFuzzTest(testutils.BaseTestCase):
       raise
 
     try:
-      uvalue = six.text_type(value)
-      uresult = six.text_type(result)
+      uvalue = str(value)
+      uresult = str(result)
     except UnicodeDecodeError:
       # This is not what we're testing.
       return

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -18,10 +18,7 @@ import collections
 import enum
 import functools
 
-import six
-
-if six.PY3:
-  from fire import test_components_py3 as py3  # pylint: disable=unused-import,no-name-in-module,g-import-not-at-top
+from fire import test_components_py3 as py3  # pylint: disable=unused-import,no-name-in-module,g-import-not-at-top
 
 
 def identity(arg1, arg2, arg3=10, arg4=20, *arg5, **arg6):  # pylint: disable=keyword-arg-before-vararg

--- a/fire/testutils.py
+++ b/fire/testutils.py
@@ -15,6 +15,7 @@
 """Utilities for Python Fire's tests."""
 
 import contextlib
+import io
 import os
 import re
 import sys
@@ -24,7 +25,6 @@ from fire import core
 from fire import trace
 
 import mock
-import six
 
 
 class BaseTestCase(unittest.TestCase):
@@ -45,8 +45,8 @@ class BaseTestCase(unittest.TestCase):
     Yields:
       Yields to the wrapped context.
     """
-    stdout_fp = six.StringIO()
-    stderr_fp = six.StringIO()
+    stdout_fp = io.StringIO()
+    stderr_fp = io.StringIO()
     try:
       with mock.patch.object(sys, 'stdout', stdout_fp):
         with mock.patch.object(sys, 'stderr', stderr_fp):
@@ -69,10 +69,7 @@ class BaseTestCase(unittest.TestCase):
                                (name, value, regexp))
 
   def assertRaisesRegex(self, *args, **kwargs):  # pylint: disable=arguments-differ
-    if sys.version_info.major == 2:
-      return super(BaseTestCase, self).assertRaisesRegexp(*args, **kwargs)  # pylint: disable=deprecated-method,no-member
-    else:
-      return super(BaseTestCase, self).assertRaisesRegex(*args, **kwargs)  # pylint: disable=no-member
+    return super(BaseTestCase, self).assertRaisesRegex(*args, **kwargs)  # pylint: disable=no-member
 
   @contextlib.contextmanager
   def assertRaisesFireExit(self, code, regexp='.*'):

--- a/fire/testutils_test.py
+++ b/fire/testutils_test.py
@@ -18,8 +18,6 @@ import sys
 
 from fire import testutils
 
-import six
-
 
 class TestTestUtils(testutils.BaseTestCase):
   """Let's get meta."""
@@ -30,15 +28,15 @@ class TestTestUtils(testutils.BaseTestCase):
         raise ValueError()
 
   def testCheckStdoutOrStderrNone(self):
-    with six.assertRaisesRegex(self, AssertionError, 'stdout:'):
+    with self.assertRaisesRegex(AssertionError, 'stdout:'):
       with self.assertOutputMatches(stdout=None):
         print('blah')
 
-    with six.assertRaisesRegex(self, AssertionError, 'stderr:'):
+    with self.assertRaisesRegex(AssertionError, 'stderr:'):
       with self.assertOutputMatches(stderr=None):
         print('blah', file=sys.stderr)
 
-    with six.assertRaisesRegex(self, AssertionError, 'stderr:'):
+    with self.assertRaisesRegex(AssertionError, 'stderr:'):
       with self.assertOutputMatches(stdout='apple', stderr=None):
         print('apple')
         print('blah', file=sys.stderr)

--- a/fire/value_types.py
+++ b/fire/value_types.py
@@ -17,10 +17,9 @@
 import inspect
 
 from fire import inspectutils
-import six
 
 
-VALUE_TYPES = (bool, six.string_types, six.integer_types, float, complex,
+VALUE_TYPES = (bool, str, bytes, int, float, complex,
                type(Ellipsis), type(None), type(NotImplemented))
 
 


### PR DESCRIPTION
This PR includes:
* assuming Python 3 for test skipping
* assuming Python 3 for fire's various type checks
* assuming Python 3 for imports (like asyncio)
* assuming Python 3 for getting function signatures
* six is no longer considered a hidden module (and so if a user of fire has six in their globals when they call Fire(), six will now show up where it used to be hidden)

This PR does not remove six from console/ code.