### PR TITLE
fix: enable typing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include fire/py.typed


### PR DESCRIPTION
seems typing with python 3.9+ does not work smoothly...
```
src/lightning_utilities/cli/__main__.py:5: error: Cannot find implementation or library stub for module named "fire"  [import-not-found]
src/lightning_utilities/cli/__main__.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 19 source files)
```
ref: https://github.com/Lightning-AI/utilities/actions/runs/11898513780/job/33155190565?pr=331
cc: @dbieber 