### PR TITLE
Visualziations of the python-fire codebase

### DIFF
--- a/.codeboarding/Argument_Input_Processing.md
+++ b/.codeboarding/Argument_Input_Processing.md
@@ -1,0 +1,71 @@
+```mermaid
+
+graph LR
+
+    Argument_Input_Processing["Argument & Input Processing"]
+
+    Core_CLI_Engine["Core CLI Engine"]
+
+    Argument_Input_Processing -- "provides processed arguments to" --> Core_CLI_Engine
+
+    Core_CLI_Engine -- "depends on" --> Argument_Input_Processing
+
+    click Argument_Input_Processing href "https://github.com/google/python-fire/blob/main/.codeboarding//Argument_Input_Processing.md" "Details"
+
+    click Core_CLI_Engine href "https://github.com/google/python-fire/blob/main/.codeboarding//Core_CLI_Engine.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Overview of Argument & Input Processing component and its relations in a CLI project
+
+
+
+### Argument & Input Processing
+
+This component is responsible for the initial parsing and processing of raw command-line arguments. It intelligently separates flags from positional arguments and performs essential type conversion, transforming string inputs (e.g., "123", "True") into their appropriate Python types (`int`, `bool`, etc.). This preparation is critical as it provides structured and typed data directly to the `Core CLI Engine` for execution.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L26-L35" target="_blank" rel="noopener noreferrer">`fire.parser.CreateParser` (26:35)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L38-L55" target="_blank" rel="noopener noreferrer">`fire.parser.SeparateFlagArgs` (38:55)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L58-L75" target="_blank" rel="noopener noreferrer">`fire.parser.DefaultParseValue` (58:75)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L78-L115" target="_blank" rel="noopener noreferrer">`fire.parser._LiteralEval` (78:115)</a>
+
+
+
+
+
+### Core CLI Engine
+
+Core CLI Engine responsible for executing commands based on processed arguments.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/CLI_Output_User_Experience.md
+++ b/.codeboarding/CLI_Output_User_Experience.md
@@ -1,0 +1,179 @@
+```mermaid
+
+graph LR
+
+    Help_Text_Generator["Help Text Generator"]
+
+    Shell_Completion_Provider["Shell Completion Provider"]
+
+    Text_Formatter["Text Formatter"]
+
+    Console_Attribute_Manager["Console Attribute Manager"]
+
+    Console_I_O_Handler["Console I/O Handler"]
+
+    Console_Pager["Console Pager"]
+
+    Encoding_Manager["Encoding Manager"]
+
+    Help_Text_Generator -- "uses" --> Text_Formatter
+
+    Help_Text_Generator -- "uses" --> Console_Pager
+
+    Shell_Completion_Provider -- "uses" --> Console_I_O_Handler
+
+    Text_Formatter -- "uses" --> Console_Attribute_Manager
+
+    Text_Formatter -- "uses" --> Console_I_O_Handler
+
+    Console_Attribute_Manager -- "uses" --> Encoding_Manager
+
+    Console_I_O_Handler -- "uses" --> Encoding_Manager
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem is crucial for how the CLI interacts with the user, ensuring that information is presented clearly, comprehensively, and efficiently. It encompasses the generation of help documentation, intelligent shell auto-completion, and robust console management for output formatting and pagination.
+
+
+
+### Help Text Generator
+
+This component is responsible for dynamically generating comprehensive and well-formatted help text for CLI commands and their arguments. It leverages introspection of the CLI application's structure and docstring information to provide users with clear guidance on how to use the CLI.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/helptext.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.helptext` (1:1)</a>
+
+
+
+
+
+### Shell Completion Provider
+
+This component provides the logic for generating shell completion suggestions. It inspects the available commands, subcommands, and arguments of a Fire CLI application to offer intelligent auto-completion, significantly enhancing the user's interaction efficiency and reducing typing errors.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/completion.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.completion` (1:1)</a>
+
+
+
+
+
+### Text Formatter
+
+This component is responsible for applying various formatting styles (e.g., bolding, colors, indentation) to text before it is displayed in the console. It ensures that CLI output is readable, visually appealing, and highlights important information effectively. It may include platform-specific formatting considerations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/formatting.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.formatting` (1:1)</a>
+
+
+
+
+
+### Console Attribute Manager
+
+This component manages console attributes such as text colors, background colors, and text styles (bold, underline). It provides an abstraction layer for applying these attributes, potentially handling platform-specific differences to ensure consistent visual output.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/console/console_attr.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.console.console_attr` (1:1)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/console/console_attr_os.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.console.console_attr_os` (1:1)</a>
+
+
+
+
+
+### Console I/O Handler
+
+This component manages the fundamental input and output operations with the console. It handles writing text to standard output and error streams, and potentially reading input. It's a core utility for any console-based application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/console/console_io.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.console.console_io` (1:1)</a>
+
+
+
+
+
+### Console Pager
+
+This component handles the pagination of large text outputs, preventing information from scrolling off the screen too quickly. It integrates with external paging utilities (like `less` or `more`) to provide a controlled viewing experience for extensive help texts or command outputs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/console/console_pager.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.console.console_pager` (1:1)</a>
+
+
+
+
+
+### Encoding Manager
+
+This component is responsible for managing character encoding for console input and output. It ensures that text is correctly encoded and decoded across different operating systems and locales, preventing display issues with special characters.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/console/encoding.py#L1-L1" target="_blank" rel="noopener noreferrer">`fire.console.encoding` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Core_CLI_Engine.md
+++ b/.codeboarding/Core_CLI_Engine.md
@@ -1,0 +1,247 @@
+```mermaid
+
+graph LR
+
+    Core_CLI_Engine["Core CLI Engine"]
+
+    Argument_Parser["Argument Parser"]
+
+    Help_Text_Generator["Help Text Generator"]
+
+    Inspection_Utilities["Inspection Utilities"]
+
+    Docstring_Parser["Docstring Parser"]
+
+    Traceback_Handler["Traceback Handler"]
+
+    Console_I_O["Console I/O"]
+
+    Completion_Handler["Completion Handler"]
+
+    Interactive_Mode["Interactive Mode"]
+
+    Core_CLI_Engine -- "uses" --> Argument_Parser
+
+    Core_CLI_Engine -- "uses" --> Traceback_Handler
+
+    Core_CLI_Engine -- "uses" --> Help_Text_Generator
+
+    Core_CLI_Engine -- "uses" --> Console_I_O
+
+    Core_CLI_Engine -- "uses" --> Inspection_Utilities
+
+    Core_CLI_Engine -- "uses" --> Completion_Handler
+
+    Core_CLI_Engine -- "uses" --> Interactive_Mode
+
+    Help_Text_Generator -- "uses" --> Inspection_Utilities
+
+    Help_Text_Generator -- "uses" --> Docstring_Parser
+
+    Traceback_Handler -- "uses" --> Inspection_Utilities
+
+    click Core_CLI_Engine href "https://github.com/google/python-fire/blob/main/.codeboarding//Core_CLI_Engine.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This analysis focuses on the `Core CLI Engine` subsystem within `python-fire`, which acts as the central orchestrator for transforming command-line inputs into Python object interactions. It dynamically dispatches commands, accesses properties, and manages the overall flow of the CLI application.
+
+
+
+### Core CLI Engine
+
+This is the central orchestrator and execution engine of `python-fire`. `fire.core.Fire` serves as the main entry point, handling initial argument parsing and delegating to `fire.core._Fire`. `fire.core._Fire` then recursively traverses the target Python object, dynamically calling methods, accessing properties, and instantiating classes based on the command-line arguments. It manages the entire lifecycle of a CLI command execution.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/core.py#L72-L163" target="_blank" rel="noopener noreferrer">`fire.core.Fire` (72:163)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/core.py#L360-L618" target="_blank" rel="noopener noreferrer">`fire.core._Fire` (360:618)</a>
+
+
+
+
+
+### Argument Parser
+
+Responsible for parsing raw command-line arguments. It separates flag arguments (e.g., `--help`, `--verbose`) from positional and keyword arguments, and prepares them for consumption by the `Core CLI Engine`. It uses Python's `argparse` module internally for flag handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.parser` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L38-L55" target="_blank" rel="noopener noreferrer">`fire.parser.SeparateFlagArgs` (38:55)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L26-L35" target="_blank" rel="noopener noreferrer">`fire.parser.CreateParser` (26:35)</a>
+
+
+
+
+
+### Help Text Generator
+
+Generates comprehensive and user-friendly help messages for CLI commands. This includes usage instructions, argument details, and descriptions, often derived from Python docstrings and object introspection.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/helptext.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.helptext` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/helptext.py#L47-L90" target="_blank" rel="noopener noreferrer">`fire.helptext.HelpText` (47:90)</a>
+
+
+
+
+
+### Inspection Utilities
+
+Offers utilities for introspecting Python objects, functions, and classes. This includes retrieving metadata such as argument specifications, docstring information, file and line numbers, and determining object types (e.g., named tuples). This information is vital for dynamic command dispatch and help generation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/inspectutils.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.inspectutils` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/inspectutils.py#L313-L332" target="_blank" rel="noopener noreferrer">`fire.inspectutils.IsNamedTuple` (313:332)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/inspectutils.py#L210-L234" target="_blank" rel="noopener noreferrer">`fire.inspectutils.GetFileAndLine` (210:234)</a>
+
+
+
+
+
+### Docstring Parser
+
+Analyzes and extracts structured information from Python docstrings. It supports various docstring formats (e.g., Google, NumPy) to provide summaries, descriptions, and details about arguments, return values, and exceptions. This parsed information is primarily consumed by the `Help Text Generator`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/docstrings.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.docstrings` (0:0)</a>
+
+
+
+
+
+### Traceback Handler
+
+Manages the recording and display of the execution path (trace) of a Fire command. It captures detailed information about accessed properties, function calls, and any errors encountered during execution, which is crucial for debugging and verbose output.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/trace.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.trace` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/trace.py#L40-L237" target="_blank" rel="noopener noreferrer">`fire.trace.FireTrace` (40:237)</a>
+
+
+
+
+
+### Console I/O
+
+Handles all interactions with the console, including displaying output (e.g., command results, error messages, help text) and managing terminal attributes. This component abstracts away the complexities of cross-platform console communication.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `fire.console` (0:0)
+
+- `fire.console.Display` (0:0)
+
+- `fire.console._PrintResult` (0:0)
+
+
+
+
+
+### Completion Handler
+
+Provides functionality for generating shell tab-completion scripts. This allows users to auto-complete commands and arguments in their terminal, significantly improving the command-line experience.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/completion.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.completion` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/completion.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.completion.CompletionScript` (0:0)</a>
+
+
+
+
+
+### Interactive Mode
+
+Enables an interactive Python REPL (Read-Eval-Print Loop) session when the `--interactive` flag is used. It embeds the current execution context, allowing users to inspect variables and interact with the CLI application's state directly.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/interact.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.interact` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/interact.py#L25-L38" target="_blank" rel="noopener noreferrer">`fire.interact.Embed` (25:38)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Execution_Trace.md
+++ b/.codeboarding/Execution_Trace.md
@@ -1,0 +1,103 @@
+```mermaid
+
+graph LR
+
+    FireTrace["FireTrace"]
+
+    FireTraceElement["FireTraceElement"]
+
+    FireTraceTest["FireTraceTest"]
+
+    FireTraceElementTest["FireTraceElementTest"]
+
+    FireTrace -- "composes" --> FireTraceElement
+
+    FireTraceTest -- "interacts with" --> FireTrace
+
+    FireTraceElementTest -- "interacts with" --> FireTraceElement
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Execution Trace` component in the `fire` project is primarily responsible for recording and managing the detailed execution path and state of a Fire application. It serves as a crucial logging mechanism for debugging, error reporting, and providing context for other components.
+
+
+
+### FireTrace
+
+This class acts as the central ledger for recording the entire execution trace of a Fire command. It maintains an ordered list of `FireTraceElement` objects, each representing a distinct step or event in the command's execution. It provides a comprehensive API to add various types of events (e.g., accessed properties, called components, errors, completion scripts, interactive modes) and to retrieve critical information about the trace, such as the final result, error status, and the reconstructed command-line arguments. Its ability to reconstruct the command is vital for debugging and understanding the exact invocation that led to a particular state or error.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `FireTraceElement` (0:0)
+
+
+
+
+
+### FireTraceElement
+
+This class represents a single, atomic event or step within the `FireTrace`. It is the fundamental building block of the entire execution log. Each `FireTraceElement` encapsulates detailed information about a specific action, including the target of the action (e.g., a function, class, or property), its arguments, return value, associated filename and line number, and any errors or metadata. Its granular nature allows for a precise and detailed reconstruction of the application's execution flow.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### FireTraceTest
+
+This class contains a suite of unit tests specifically designed to validate the correct behavior of the `FireTrace` class. It covers various scenarios, including initialization, result retrieval, error handling, and the proper addition and representation of different types of trace elements. This component ensures the reliability and accuracy of the `FireTrace` mechanism.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `FireTrace` (0:0)
+
+
+
+
+
+### FireTraceElementTest
+
+This class provides unit tests focused on verifying the functionality of the `FireTraceElement` class. It ensures that individual trace events are correctly stored, represented, and that methods like `HasError` and `__str__` behave as expected. This component is crucial for maintaining the integrity of the basic trace event unit.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `FireTraceElement` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Object_Introspection_Docstring_Parsing.md
+++ b/.codeboarding/Object_Introspection_Docstring_Parsing.md
@@ -1,0 +1,151 @@
+```mermaid
+
+graph LR
+
+    Docstring_Parser["Docstring Parser"]
+
+    Docstring_Line_Processor["Docstring Line Processor"]
+
+    Docstring_Section_State_Manager["Docstring Section State Manager"]
+
+    Argument_Specification_Resolver["Argument Specification Resolver"]
+
+    Callable_Argument_Info_Helper["Callable Argument Info Helper"]
+
+    Python_3_ArgSpec_Adapter["Python 3 ArgSpec Adapter"]
+
+    Docstring_Parser -- "uses" --> Docstring_Line_Processor
+
+    Docstring_Line_Processor -- "uses" --> Docstring_Section_State_Manager
+
+    Argument_Specification_Resolver -- "uses" --> Callable_Argument_Info_Helper
+
+    Argument_Specification_Resolver -- "uses" --> Python_3_ArgSpec_Adapter
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Object Introspection & Docstring Parsing` component in Python Fire is fundamental for dynamically understanding Python objects and their documentation. It enables Fire to automatically generate command-line interfaces and provide helpful usage information.
+
+
+
+### Docstring Parser
+
+This is the primary function responsible for analyzing and extracting structured information from Python docstrings. It supports Google, NumPy, and reStructuredText docstring formats, aiming for permissive parsing to handle variations. It produces a `DocstringInfo` object containing the summary, description, and details about arguments, return values, yields, and exceptions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/docstrings.py#L117-L207" target="_blank" rel="noopener noreferrer">`fire.docstrings.parse` (117:207)</a>
+
+
+
+
+
+### Docstring Line Processor
+
+An internal helper function used by the `Docstring Parser` to process individual lines of a docstring. It updates the parsing state based on the line's content, identifying directives, argument names, types, and descriptions within different docstring sections.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/docstrings.py#L410-L506" target="_blank" rel="noopener noreferrer">`fire.docstrings._consume_line` (410:506)</a>
+
+
+
+
+
+### Docstring Section State Manager
+
+This internal helper function, called by `Docstring Line Processor`, determines the current section (e.g., "Args:", "Returns:") and the formatting style (Google, NumPy, and reStructuredText) of the docstring based on the current and surrounding lines. It updates the parser's state accordingly.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/docstrings.py#L532-L573" target="_blank" rel="noopener noreferrer">`fire.docstrings._update_section_state` (532:573)</a>
+
+
+
+
+
+### Argument Specification Resolver
+
+This function retrieves a detailed argument specification (`FullArgSpec`) for a given Python callable (function, method, or class). It handles various Python versions and edge cases, such as built-in functions and named tuples, to accurately determine the expected arguments.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/inspectutils.py#L162-L207" target="_blank" rel="noopener noreferrer">`fire.inspectutils.GetFullArgSpec` (162:207)</a>
+
+
+
+
+
+### Callable Argument Info Helper
+
+A helper function used by `Argument Specification Resolver` to determine if the first argument of a callable should be skipped (e.g., `self` for bound methods or `__init__` for classes) and which function's arg spec should be used for introspection.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/inspectutils.py#L49-L84" target="_blank" rel="noopener noreferrer">`fire.inspectutils._GetArgSpecInfo` (49:84)</a>
+
+
+
+
+
+### Python 3 ArgSpec Adapter
+
+This function provides a Python 3-specific implementation for retrieving the full argument specification. It leverages `inspect._signature_from_callable` to correctly handle bound arguments and follow wrapper chains, ensuring compatibility with modern Python features.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/inspectutils.py#L87-L157" target="_blank" rel="noopener noreferrer">`fire.inspectutils.Py3GetFullArgSpec` (87:157)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,167 @@
+```mermaid
+
+graph LR
+
+    Core_CLI_Engine["Core CLI Engine"]
+
+    Argument_Input_Processing["Argument & Input Processing"]
+
+    Object_Introspection_Docstring_Parsing["Object Introspection & Docstring Parsing"]
+
+    CLI_Output_User_Experience["CLI Output & User Experience"]
+
+    Execution_Trace["Execution Trace"]
+
+    Core_CLI_Engine -- "Uses" --> Argument_Input_Processing
+
+    Core_CLI_Engine -- "Uses" --> Object_Introspection_Docstring_Parsing
+
+    Core_CLI_Engine -- "Updates" --> Execution_Trace
+
+    Core_CLI_Engine -- "Delegates to" --> CLI_Output_User_Experience
+
+    Argument_Input_Processing -- "Provides input to" --> Core_CLI_Engine
+
+    Object_Introspection_Docstring_Parsing -- "Provides metadata to" --> Core_CLI_Engine
+
+    Object_Introspection_Docstring_Parsing -- "Provides content to" --> CLI_Output_User_Experience
+
+    CLI_Output_User_Experience -- "Receives data from" --> Core_CLI_Engine
+
+    CLI_Output_User_Experience -- "Uses" --> Object_Introspection_Docstring_Parsing
+
+    CLI_Output_User_Experience -- "Uses" --> Execution_Trace
+
+    Execution_Trace -- "Receives updates from" --> Core_CLI_Engine
+
+    Execution_Trace -- "Provides context to" --> CLI_Output_User_Experience
+
+    click Core_CLI_Engine href "https://github.com/google/python-fire/blob/main/.codeboarding//Core_CLI_Engine.md" "Details"
+
+    click Argument_Input_Processing href "https://github.com/google/python-fire/blob/main/.codeboarding//Argument_Input_Processing.md" "Details"
+
+    click Object_Introspection_Docstring_Parsing href "https://github.com/google/python-fire/blob/main/.codeboarding//Object_Introspection_Docstring_Parsing.md" "Details"
+
+    click CLI_Output_User_Experience href "https://github.com/google/python-fire/blob/main/.codeboarding//CLI_Output_User_Experience.md" "Details"
+
+    click Execution_Trace href "https://github.com/google/python-fire/blob/main/.codeboarding//Execution_Trace.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `python-fire` library's architecture is elegantly designed around the concept of dynamically generating command-line interfaces from arbitrary Python objects. The analysis of the Control Flow Graph (CFG) and Source Analysis reveals a clear separation of concerns, with a central core orchestrating various specialized components for parsing, introspection, output, and state management. The five fundamental components are: Core CLI Engine, Argument & Input Processing, Object Introspection & Docstring Parsing, CLI Output & User Experience, and Execution Trace. These components cover the entire lifecycle of a Fire CLI: from receiving user input, understanding the target Python object, executing the desired action, managing the execution state, and finally, presenting information back to the user.
+
+
+
+### Core CLI Engine
+
+This is the central orchestrator and execution engine of `python-fire`. It takes a Python object and command-line arguments, then dynamically dispatches commands, accesses properties, and manages the overall flow of the CLI application. It encompasses the high-level control of `fire.core.Fire` and the recursive object traversal logic of `fire.core._Fire`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/core.py#L72-L163" target="_blank" rel="noopener noreferrer">`fire.core.Fire` (72:163)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/core.py#L360-L618" target="_blank" rel="noopener noreferrer">`fire.core._Fire` (360:618)</a>
+
+
+
+
+
+### Argument & Input Processing
+
+This component is responsible for parsing raw command-line arguments. It separates flags from positional arguments and converts string inputs into appropriate Python types (e.g., "123" to `int`, "True" to `bool`), preparing them for the Core CLI Engine.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/parser.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.parser` (0:0)</a>
+
+
+
+
+
+### Object Introspection & Docstring Parsing
+
+This component provides the foundational capability to dynamically inspect Python objects (modules, classes, functions) to extract their structure, argument specifications, and docstring content. This information is critical for Fire's auto-CLI generation and for producing informative help messages.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/inspectutils.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.inspectutils` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/docstrings.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.docstrings` (0:0)</a>
+
+
+
+
+
+### CLI Output & User Experience
+
+This component manages all aspects of how the CLI interacts with the user and presents information. This includes generating comprehensive help text, providing shell completion suggestions, handling paginated output for large texts, and applying formatting (bolding, colors) to enhance readability.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/helptext.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.helptext` (0:0)</a>
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/completion.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.completion` (0:0)</a>
+
+- `fire.console` (0:0)
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/formatting.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.formatting` (0:0)</a>
+
+
+
+
+
+### Execution Trace
+
+This is a dedicated component for recording the detailed execution path and state of a Fire application. It captures accessed properties, called functions, and any errors, serving as a crucial log for debugging, error reporting, and providing context for other components like help generation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google/python-fire/blob/master/fire/trace.py#L0-L0" target="_blank" rel="noopener noreferrer">`fire.trace` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the python-fire codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/python-fire/on_boarding.md

These diagrams help users quickly grasp the codebase. Google is a huge organization so I would love to hear what is your current on-boarding process, when it comes to working with new codebases. Do you think that such diagrams can have place in it? We are generating the with static analysis and LLMs, so they are based on the code itself without external resources.

Any feedback is more than welcome! We've just released a free GitHub Action that can automatically update the diagrams and this way keep them always up-to-date.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.