### PR TITLE
Fix completion suggesting --self for class-grouped commands

### DIFF
--- a/fire/completion.py
+++ b/fire/completion.py
@@ -379,6 +379,14 @@ def _CompletionsFromArgs(fn_args):
   Returns:
     A list of possible completion strings for that function.
   """
+  # Completion should not suggest implicit bound args.
+  #
+  # When generating completions, Fire may inspect unbound methods (functions
+  # retrieved from a class). These will include "self" or "cls" in the argspec,
+  # even though users can never pass those via the CLI.
+  if fn_args and fn_args[0] in ('self', 'cls'):
+    fn_args = fn_args[1:]
+
   completions = []
   for arg in fn_args:
     arg = arg.replace('_', '-')

--- a/repro_issue_382.py
+++ b/repro_issue_382.py
@@ -1,0 +1,69 @@
+import os
+import sys
+
+# Use local Fire without installing.
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Fire depends on termcolor for pretty output; to keep this repro standalone
+# in minimal environments, provide a tiny stub.
+try:
+    import termcolor  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    import types
+
+    termcolor = types.SimpleNamespace(colored=lambda s, *args, **kwargs: s)
+    sys.modules["termcolor"] = termcolor
+
+import fire
+
+
+class Foo:
+    def bar(self):
+        return "bar"
+
+    def do_stuff(self, arg1):
+        return f"stuff {arg1}"
+
+
+def main() -> None:
+    # Enable completion output.
+    # In Fire, `-- --completion` is passed after the Fire arguments separator.
+    # We'll call Fire in a way that simulates CLI invocation.
+    #
+    # The bug report says that completion output includes a `--self` flag, which should
+    # never be suggested to the user.
+    argv = [
+        "prog",
+        "--",
+        "--completion",
+    ]
+
+    # Fire uses sys.argv.
+    old_argv = sys.argv
+    try:
+        sys.argv = argv
+        # Fire writes completion script to stdout. Capture by redirecting.
+        from io import StringIO
+        import contextlib
+
+        buf = StringIO()
+        with contextlib.redirect_stdout(buf):
+            try:
+                fire.Fire(Foo)
+            except SystemExit as e:
+                # Fire may exit after printing completion.
+                if e.code not in (0, None):
+                    raise
+
+        out = buf.getvalue()
+    finally:
+        sys.argv = old_argv
+
+    assert "--self" not in out, (
+        "Completion output must not include the implicit 'self' parameter as a flag.\n"
+        f"Output was:\n{out[:2000]}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes google/python-fire issue #382: https://github.com/google/python-fire/issues/382

What happened
When using a class as the Fire component (to group commands), Fire’s --completion output could include the implicit bound argument self as a CLI flag (--self). This is confusing and incorrect since users can never pass self explicitly.

Example symptom (from completion script output):

opts="--arg1 --self ${GLOBAL_OPTIONS}"
opts="--self ${GLOBAL_OPTIONS}"
Root cause
The completion generator builds option flags from the callable’s argspec:

Completions() → inspectutils.GetFullArgSpec(component) → _CompletionsFromArgs(spec.args + spec.kwonlyargs)
For unbound methods (functions retrieved from a class), spec.args includes self (or cls), because Python includes that parameter in the signature even though it is implicitly supplied at call time.
_CompletionsFromArgs was converting every arg name into a --<arg> completion, which incorrectly produced --self.

Fix
In fire/completion.py, _CompletionsFromArgs now skips a leading self / cls argument when present. This ensures completion suggestions only contain user-supplied parameters.

This is a minimal, targeted change that affects only completion flag generation from argument lists.

Reproduction
A standalone repro script is included:

python3 repro_issue_382.py
It generates completion output for a small example class and asserts that --self is not present in the completion script.

Tests
python3 -m unittest fire.completion_test -q
Notes
This change is limited to completion generation. It does not affect Fire’s argument parsing or invocation behavior.
Existing test testMethodCompletions already asserts that --self should not appear; this change ensures the completion script output also respects that constraint in the class-grouping scenario.