### PR TITLE
Fix HasCustomStr to recognise custom __repr__ as a meaningful str (fixes #595)

### DIFF
--- a/fire/core_test.py
+++ b/fire/core_test.py
@@ -161,6 +161,19 @@ class CoreTest(testutils.BaseTestCase):
     with self.assertOutputMatches(stdout='11', stderr=None):
       core.Fire(tc.NamedTuple, command=['point', '-2'])
 
+  def testPrintObjectWithCustomStr(self):
+    # An object that overrides __str__ should be printed as a value, not shown
+    # as a help screen (regression test for github.com/google/python-fire#595).
+    with self.assertOutputMatches(stdout='custom str', stderr=None):
+      core.Fire(tc.fn_returning_custom_str, command=[])
+
+  def testPrintObjectWithCustomRepr(self):
+    # An object that overrides only __repr__ should also be printed as a value
+    # because Python's object.__str__ delegates to __repr__.
+    # Regression test for github.com/google/python-fire#595.
+    with self.assertOutputMatches(stdout='ClassWithCustomRepr()', stderr=None):
+      core.Fire(tc.fn_returning_custom_repr, command=[])
+
   def testCallable(self):
     with self.assertOutputMatches(stdout=r'foo:\s+foo\s+', stderr=None):
       core.Fire(tc.CallableWithKeywordArgument(), command=['--foo=foo'])

--- a/fire/test_components.py
+++ b/fire/test_components.py
@@ -566,3 +566,25 @@ def fn_with_multiple_defaults(first='first', last='last', late='late'):
   del last, late
   return first
 # pylint: enable=g-doc-args,g-doc-return-or-yield
+
+
+class ClassWithCustomRepr:
+  """Class that overrides __repr__ but not __str__."""
+
+  def __repr__(self):
+    return 'ClassWithCustomRepr()'
+
+
+class ClassWithCustomStr:
+  """Class that overrides __str__ but not __repr__."""
+
+  def __str__(self):
+    return 'custom str'
+
+
+def fn_returning_custom_repr():
+  return ClassWithCustomRepr()
+
+
+def fn_returning_custom_str():
+  return ClassWithCustomStr()

--- a/fire/value_types.py
+++ b/fire/value_types.py
@@ -15,8 +15,17 @@
 """Types of values."""
 
 import inspect
+import sys
 
 from fire import inspectutils
+
+# Names of all Python standard-library modules, used to distinguish user-
+# defined types from stdlib types in HasCustomStr.  sys.stdlib_module_names
+# was added in Python 3.10; fall back to a minimal sentinel set for older
+# interpreters so the guard still works for the most common cases.
+_STDLIB_MODULE_NAMES = frozenset(
+    getattr(sys, 'stdlib_module_names', {'builtins', 'collections', 'abc'})
+)
 
 
 VALUE_TYPES = (bool, str, bytes, int, float, complex,
@@ -56,25 +65,42 @@ def IsSimpleGroup(component):
 
 
 def HasCustomStr(component):
-  """Determines if a component has a custom __str__ method.
+  """Determines if a component has a meaningful custom string representation.
 
   Uses inspect.classify_class_attrs to determine the origin of the object's
-  __str__ method, if one is present. If it defined by `object` itself, then
+  __str__ and __repr__ methods.  If __str__ is defined by `object` itself, then
   it is not considered custom. Otherwise it is. This means that the __str__
   methods of primitives like ints and floats are considered custom.
 
-  Objects with custom __str__ methods are treated as values and can be
+  Python's default object.__str__ delegates to __repr__, so a class that
+  overrides __repr__ but not __str__ also produces a meaningful custom string
+  via str(). Such objects are likewise treated as having a custom str.
+
+  Objects with a meaningful str representation are treated as values and can be
   serialized in places where more complex objects would have their help screen
   shown instead.
 
   Args:
     component: The object to check for a custom __str__ method.
   Returns:
-    Whether `component` has a custom __str__ method.
+    Whether `component` has a custom string representation.
   """
   if hasattr(component, '__str__'):
     class_attrs = inspectutils.GetClassAttrsDict(type(component)) or {}
     str_attr = class_attrs.get('__str__')
     if str_attr and str_attr.defining_class is not object:
       return True
+    # If __str__ is inherited from object but __repr__ is overridden by a
+    # *user-defined* (non-stdlib) class, str(component) will use that custom
+    # __repr__ (because object.__str__ delegates to __repr__).  Treat this as
+    # a meaningful custom string too.
+    # Exclude stdlib types (dict, list, OrderedDict, …) whose __repr__ is
+    # defined in the standard library — Fire still treats those as navigable
+    # groups, not values.
+    repr_attr = class_attrs.get('__repr__')
+    if repr_attr and repr_attr.defining_class is not object:
+      defining_module = repr_attr.defining_class.__module__ or ''
+      top_level_module = defining_module.split('.')[0]
+      if top_level_module not in _STDLIB_MODULE_NAMES:
+        return True
   return False


### PR DESCRIPTION
## Summary

Fixes #595.

Objects that override `__repr__` but not `__str__` (e.g. `datasets.Dataset` from HuggingFace) were shown as a help screen instead of being printed, because `HasCustomStr` only checked for a custom `__str__`.

---

## Problem

Python's `object.__str__` delegates to `__repr__`, so a class that defines a custom `__repr__` already produces a meaningful custom string via `str(obj)` — even without defining `__str__`. However, `HasCustomStr` in `value_types.py` only inspected `__str__`:

```python
str_attr = class_attrs.get('__str__')
if str_attr and str_attr.defining_class is not object:
    return True
# __repr__-only classes fall through → False → help screen shown
```

This caused `fire.Fire(main)` to show the `datasets.Dataset` help screen rather than the dataset's repr string.

---

## Solution

After the existing `__str__` check, also look for a custom `__repr__` — but only on **user-defined (non-stdlib) types**, so that Python built-in containers (`dict`, `list`, `OrderedDict`, …) continue to be treated as navigable groups rather than values.

The guard uses `sys.stdlib_module_names` (Python ≥ 3.10) and falls back to a minimal sentinel set for older interpreters:

```python
_STDLIB_MODULE_NAMES = frozenset(
    getattr(sys, 'stdlib_module_names', {'builtins', 'collections', 'abc'})
)
```

If the `__repr__`-defining class's top-level module is not in that set, the object is treated as a value.

---

## Testing

Added to `test_components.py`:
- `ClassWithCustomRepr` — overrides `__repr__` only
- `ClassWithCustomStr`  — overrides `__str__` only (existing behaviour)
- `fn_returning_custom_repr` / `fn_returning_custom_str` — functions returning those objects

Added to `core_test.py`:
- `testPrintObjectWithCustomStr` — existing `__str__` path still works
- `testPrintObjectWithCustomRepr` — new `__repr__` path: output is `ClassWithCustomRepr()`, not a help screen

Run command: `python3 -m pytest fire/ --ignore=fire/docstrings_fuzz_test.py --ignore=fire/parser_fuzz_test.py`
**262 tests pass, 0 failures.**

---

## Checklist

- [x] Fixes the reported issue
- [x] Existing behaviour unchanged (no regressions — dict/list/OrderedDict still show help screens)
- [x] Tests added
- [x] All 262 tests pass
- [x] Code style matches project conventions