### PR TITLE
feat: add xontrib to support Fire in the xonsh shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,31 @@ Please see [The Python Fire Guide](docs/guide.md).
 
 _Note that these flags are separated from the Fire command by an isolated `--`._
 
+## Xonsh shell support
+
+```xsh
+xpip install fire
+xontrib load fire
+
+obj = {'var': 'val'}
+fire obj var
+# val
+
+type(@.env)
+# xonsh.environ.Env
+fire @.env get USER - upper
+# PC
+
+type(@.imp)
+# xonsh.built_ins.InlineImporter
+fire @.imp.json dumps --help
+# @.imp.json dumps OBJ <flags>
+fire @.imp.json dumps '{"a":1}' --indent 4
+# {
+#    "a": 1
+# }
+```
+
 ## License
 
 Licensed under the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["fire*"]
+include = ["fire*", "xontrib*"]
 
 [tool.setuptools.package-data]
 fire = ["console/*"]

--- a/xontrib/fire.py
+++ b/xontrib/fire.py
@@ -1,7 +1,8 @@
 """Turns any object into a CLI tool using Fire in the xonsh shell."""
 
+
 @aliases.register
-def _fire(args, stdout, stderr):
+def _fire(args, stdout):
     """Turns any object into a CLI tool using Fire in the xonsh shell."""
     if len(args) == 0:
         print('Usage: fire <object name> [args|--help]', file=stderr)
@@ -12,5 +13,9 @@ def _fire(args, stdout, stderr):
         import fire
         fire.core.Display = lambda lines, out: stdout.write("\n".join(lines) + "\n")
         return fire
+    try:
+        obj = eval(args[0])
+    except:
+        obj = evalx(args[0])
     with __xonsh__.env.swap(UPDATE_OS_ENVIRON=True, PAGER='-'):
-        fixed_fire().Fire(evalx(args[0]), command=args[1:], name=args[0])
+        fixed_fire().Fire(obj, command=args[1:], name=args[0])

--- a/xontrib/fire.py
+++ b/xontrib/fire.py
@@ -1,0 +1,16 @@
+"""Turns any object into a CLI tool using Fire in the xonsh shell."""
+
+@aliases.register
+def _fire(args, stdout, stderr):
+    """Turns any object into a CLI tool using Fire in the xonsh shell."""
+    if len(args) == 0:
+        print('Usage: fire <object name> [args|--help]', file=stderr)
+        print('Example: fire @ --help', file=stderr)
+        return 1
+    def fixed_fire():
+        """Fix https://github.com/google/python-fire/issues/188"""
+        import fire
+        fire.core.Display = lambda lines, out: stdout.write("\n".join(lines) + "\n")
+        return fire
+    with __xonsh__.env.swap(UPDATE_OS_ENVIRON=True, PAGER='-'):
+        fixed_fire().Fire(evalx(args[0]), command=args[1:], name=args[0])


### PR DESCRIPTION
Workflow:

```xsh
xonsh
xpip install fire  # xontrib will be installed with the main package seamlessly.
xontrib load fire

type(@)
# xonsh.built_ins.XonshSessionInterface
fire @ --help
# @ - Xonsh Session Interface

obj = {'var': 'val'}
fire obj var
# val

type(@.env)
# xonsh.environ.Env
fire @.env get USER - upper
# PC

type(aliases)
# xonsh.aliases.Aliases
fire aliases get ls
# ls -G

type(@.imp)
# xonsh.built_ins.InlineImporter
fire @.imp.json dumps --help
# @.imp.json dumps OBJ <flags>
fire @.imp.json dumps '{"a":1}' --indent 4
# {
#    "a": 1
# }
```