### PR TITLE
fix: preserve chained flags after kwargs calls

### DIFF
--- a/fire/core.py
+++ b/fire/core.py
@@ -853,6 +853,10 @@ def _ParseKeywordArgs(args, fn_spec):
     return kwargs, remaining_kwargs, remaining_args
 
   skip_argument = False
+  positional_capacity = (
+      None if fn_spec.varargs is not None else len(fn_spec.args))
+  explicit_positional_kwargs = set()
+  seen_bare_args = 0
 
   for index, argument in enumerate(args):
     if skip_argument:
@@ -881,6 +885,14 @@ def _ParseKeywordArgs(args, fn_spec):
       key = key.replace('-', '_')
       is_bool_syntax = (not contains_equals and
                         (index + 1 == len(args) or _IsFlag(args[index + 1])))
+
+      if (positional_capacity is not None
+          and seen_bare_args > positional_capacity):
+        remaining_kwargs.append(argument)
+        if not contains_equals and not is_bool_syntax:
+          remaining_kwargs.append(args[index + 1])
+          skip_argument = True
+        continue
 
       # Determine the keyword.
       keyword = ''  # Indicates no valid keyword has been found yet.
@@ -929,11 +941,17 @@ def _ParseKeywordArgs(args, fn_spec):
       skip_argument = not contains_equals and not is_bool_syntax
       if got_argument:
         kwargs[keyword] = value
+        if (keyword in fn_spec.args
+            and keyword not in explicit_positional_kwargs):
+          explicit_positional_kwargs.add(keyword)
+          if positional_capacity is not None:
+            positional_capacity = max(positional_capacity - 1, 0)
       else:
         remaining_kwargs.append(argument)
         if skip_argument:
           remaining_kwargs.append(args[index + 1])
     else:  # not _IsFlag(argument)
+      seen_bare_args += 1
       remaining_args.append(argument)
 
   return kwargs, remaining_kwargs, remaining_args

--- a/fire/fire_test.py
+++ b/fire/fire_test.py
@@ -14,6 +14,7 @@
 
 """Tests for the fire module."""
 
+from dataclasses import dataclass
 import os
 import sys
 from unittest import mock
@@ -249,6 +250,25 @@ class FireTest(testutils.BaseTestCase):
             tc.Kwargs,
             command=['upper', '--alpha', 'A', '--beta', 'B', '-', 'lower']),
         'alpha beta')
+
+  def testFireKeywordArgsChainedCall(self):
+    @dataclass
+    class MyClass:
+      x: int
+
+      def transform(self, **kwargs):
+        return MyClass(self.x * kwargs.get('multiplier', 2))
+
+      def do_something(self, msg):
+        return f'{msg}: {self.x}'
+
+    my_obj = MyClass(3)
+    self.assertEqual(
+        fire.Fire(
+            my_obj,
+            command=['transform', '--multiplier=3', 'do_something',
+                     '--msg=test']),
+        'test: 9')
 
   def testFireKeywordArgsWithMissingPositionalArgs(self):
     self.assertEqual(


### PR DESCRIPTION
Avoid greedily consuming flags into an intermediate callable when it accepts **kwargs and the command continues into a chained call. Keep those flags available for the next component in the chain.

Add a regression test for the dataclass example from issue #659.

Refs #659.